### PR TITLE
Second round of figure improvements

### DIFF
--- a/themes/pelican-bootstrap3/static/css/style.css
+++ b/themes/pelican-bootstrap3/static/css/style.css
@@ -89,7 +89,6 @@ a, a:hover {
 }
 
 .entry-content img {
-    max-width: 100%;
     height: auto;
 }
 
@@ -241,6 +240,9 @@ article {
     margin-bottom: 20px;
     padding: 4px;
     transition: all 0.2s ease-in-out 0s;
+    width: -moz-min-content;
+    width: -webkit-min-content;
+    width: min-content;
 }
 
 .figure p.caption {


### PR DESCRIPTION
Fix figure box width when the caption exceeds image width. An example can be seen [here](http://castalio.info/johan-dahlin-stoq-gestor-comercial-livre.html).
