### PR TITLE
Adds site brand at the sidebar

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -78,11 +78,9 @@ SITEMAP = {
 DISQUS_SITENAME = 'castliopodcast'
 GOOGLE_ANALYTICS = "UA-21449168-1"
 
-BANNER = True
-BANNER_SUBTITLE = u"Um podcast inspirado prá castálio!"
-BANNER_BACKGROUND_GRADIENT = 'linear-gradient(#2a2a29, #1c1c1c)'
-BANNER_IMAGE = 'images/castalio-podcast.jpg'
-BANNER_IMAGE_HEIGHT = 250
+SIDEBAR_BRAND_SUBTITLE = u"Um podcast inspirado prá castálio!"
+SIDEBAR_BRAND_IMAGE = 'images/castalio-podcast.jpg'
+SIDEBAR_BRAND_IMAGE_HEIGHT = 200
 FAVICON = 'images/favicon.ico'
 
 # iTunes plugin settings

--- a/themes/pelican-bootstrap3/static/css/style.css
+++ b/themes/pelican-bootstrap3/static/css/style.css
@@ -289,3 +289,11 @@ img.align-center, .figure.align-center{
     margin-top: 0.7em;
     margin-bottom: 1.5em;
 }
+
+#sidebar-brand {
+	margin-bottom: 30px;
+}
+
+#sidebar-sitename {
+	font-size: 35px;
+}

--- a/themes/pelican-bootstrap3/templates/includes/sidebar.html
+++ b/themes/pelican-bootstrap3/templates/includes/sidebar.html
@@ -2,6 +2,19 @@
     {% set DISPLAY_TAGS_ON_SIDEBAR = True %}
 {% endif %}
 
+{% if SIDEBAR_BRAND_IMAGE %}
+    <div id="sidebar-brand" class="sidebar-brand text-center">
+        <a href="{{ SITEURL }}">
+            <img height="{{ SIDEBAR_BRAND_IMAGE_HEIGHT }}" class="img-circle" alt="{{ SITENAME }}" src="{{ SITEURL }}/{{ SIDEBAR_BRAND_IMAGE }}">
+        </a>
+
+        <h1 id="sidebar-sitename">{{ SITENAME }}</h1>
+    {% if SIDEBAR_BRAND_SUBTITLE %}
+        <p class="text-muted">{{ SIDEBAR_BRAND_SUBTITLE }}</p>
+    {% endif %}
+    </div>
+{% endif %}
+
 <section class="well well-sm">
     <ul class="list-group list-group-flush">
         {% if SOCIAL %}


### PR DESCRIPTION
Removes the large site banner and adds a nice little sidebar brand: 
![melhoria-castalio-2015-01-05](https://cloud.githubusercontent.com/assets/353311/5618397/d0b89368-94ff-11e4-9c4b-c11b83d68bb6.png)
