### PR TITLE
Implements Tag Cloud

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -14,8 +14,11 @@ DEFAULT_LANG = u'pt'
 LANG = u'pt_BR.UTF-8'
 CC_LICENSE = u'CC-BY-NC-SA'
 
+# Sets Tagcloud usage
 TAG_CLOUD_STEPS = 8
-TAG_CLOUD_MAX_ITEMS = 10
+TAG_CLOUD_MAX_ITEMS = 150
+DISPLAY_TAGS_INLINE = True
+
 
 # Feed generation is usually not desired when developing
 FEED_ALL_ATOM = 'feeds.atom'

--- a/themes/pelican-bootstrap3/static/css/style.css
+++ b/themes/pelican-bootstrap3/static/css/style.css
@@ -23,23 +23,35 @@ body {
 }
 
 .tag-0 {
-    font-size: 16pt;
+    font-size: 23pt;
 }
 
 .tag-1 {
-    font-size: 13pt;
+    font-size: 20pt;
 }
 
 .tag-2 {
-    font-size: 10pt;
+    font-size: 18pt;
 }
 
 .tag-3 {
-    font-size: 8pt;
+    font-size: 15pt;
 }
 
 .tag-4 {
-    font-size: 6pt;
+    font-size: 12pt;
+}
+
+.tag-5 {
+    font-size: 9pt;
+}
+
+.tag-6 {
+    font-size: 7pt;
+}
+
+.tag-7 {
+    font-size: 5pt;
 }
 
 #aboutme {
@@ -296,4 +308,8 @@ img.align-center, .figure.align-center{
 
 #sidebar-sitename {
 	font-size: 35px;
+}
+
+.tagcloud{
+	padding-left: 20px;
 }

--- a/themes/pelican-bootstrap3/templates/includes/sidebar.html
+++ b/themes/pelican-bootstrap3/templates/includes/sidebar.html
@@ -65,14 +65,16 @@
         {% endif %}
 
         {% if DISPLAY_TAGS_ON_SIDEBAR %}
+        {#
             {% if DISPLAY_TAGS_INLINE %}
                 {% set tags = tag_cloud | sort(attribute='0') %}
             {% else %}
                 {% set tags = tag_cloud | sort(attribute='1') %}
             {% endif %}
+        #}
             <li class="list-group-item"><a href="{{ SITEURL }}/{{ TAGS_URL }}"><h4><i class="fa fa-tags fa-lg"></i><span class="icon-label">Tags</span></h4></a>
                 <ul class="list-group {% if DISPLAY_TAGS_INLINE %}list-inline tagcloud{% endif %}" id="tags">
-                {% for tag in tags %}
+                {% for tag in tag_cloud %}
                     <li class="list-group-item tag-{{ tag.1 }}">
                         <a href="{{ SITEURL }}/{{ tag.0.url }}">
                             {{ tag.0 }}


### PR DESCRIPTION
Sets some properties for tag cloud usage (steps and max items), tweaks some CSS and disable tag cloud sorting in order to keep a good compiling time.

![castalio-tag-cloud](https://cloud.githubusercontent.com/assets/353311/5620724/9db66d4e-9515-11e4-8769-a66206958ca9.png)
