### PR TITLE
Dynamic copyright year and updated robot.txt.

### DIFF
--- a/content/extra/robots.txt
+++ b/content/extra/robots.txt
@@ -2,6 +2,7 @@ User-agent: *
 
 Sitemap: http://castalio.info/sitemap.xml
 
+Disallow: /archives.html
 Disallow: /author/*
 Disallow: /category/*
 Disallow: /feeds/*

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*- #
 from __future__ import unicode_literals
+from datetime import datetime
 
 AUTHOR = u'Og Maciel & Elyézer Rezende'
 SITENAME = u'Castálio Podcast'
@@ -96,7 +97,8 @@ ITUNES_FEED_PATH = u'feeds/podcast.rss'
 ITUNES_FEED_TITLE = u'Castálio Podcast'
 ITUNES_FEED_EXPLICIT = u'No'
 ITUNES_FEED_LANGUAGE = u'pt-br'
-ITUNES_FEED_COPYRIGHT = u'&#x2117; &amp; &#xA9; 2011-2015 Og Maciel e Elyézer Rezende'
+ITUNES_FEED_COPYRIGHT = u'&#x2117; &amp; &#xA9; 2011-{0} {1}'.format(
+    datetime.now().year, AUTHOR)
 ITUNES_FEED_SUBTITLE = u'Um podcast inspirado para castálio'
 ITUNES_FEED_AUTHOR = u'Og Maciel'
 ITUNES_FEED_SUMMARY = u''


### PR DESCRIPTION
Use ``datetime.now().year`` to figure out the 'end year' for the
copyright message. Also, disallow bots from indexing ``archives.html``.