### PR TITLE
Suggestion intro music highlight

### DIFF
--- a/content/episodes/061-humberto-zanetti-smart-braille.rst
+++ b/content/episodes/061-humberto-zanetti-smart-braille.rst
@@ -107,7 +107,9 @@ Links
 * `Filme O Código Da Vinci`_
 * `Filme Snatch`_
 
-\*\ **Música**: `Ain't Gonna Give Jelly Roll`_ by `Red Hook Ramblers`_ is licensed under a Creative Commons Attribution-NonCommercial-NoDerivatives (aka Music Sharing) License.
+.. class:: panel-body bg-info
+
+        **Música**: `Ain't Gonna Give Jelly Roll`_ by `Red Hook Ramblers`_ is licensed under a Creative Commons Attribution-NonCommercial-NoDerivatives (aka Music Sharing) License.
 
 .. Mentioned
 .. _Vídeo – Open hardware, open mind: http://imasters.com.br/open-hardware-2/video-open-hardware-open-mind-7masters/


### PR DESCRIPTION
Adds the directive `.. class:: panel-body bg-info`, which will highlight the paragraph that cites the intro music.

Printscreen:
![castalio-intro-music-highlight](https://cloud.githubusercontent.com/assets/353311/5913251/d33de9fc-a5c7-11e4-8ea0-854b959dfb93.png)

If accepted I may add this same style to all articles.