### PR TITLE
Standardize Link References

### DIFF
--- a/content/episodes/001-og-maciel.rst
+++ b/content/episodes/001-og-maciel.rst
@@ -11,11 +11,11 @@ Episódio Zero: Og Maciel
 
    Episódio Zero
 
-Apresentando o primeiro episódio do **Castalio**. O entrevistado neste
-episódio é o\ `Og Maciel <http://www.ogmaciel.com>`__, conhecido
-contribuinte do mundo do software livre, e atual membro da mesa diretora
-do **GNOME Foundation**. Por este ter sido o primeiro episódio, abusamos
-do Og e perguntamos várias coisas sobre assuntos variádos, como:
+Apresentando o primeiro episódio do **Castalio**. O entrevistado neste episódio
+é o `Og Maciel`_, conhecido contribuinte do mundo do software livre, e atual
+membro da mesa diretora do **GNOME Foundation**. Por este ter sido o primeiro
+episódio, abusamos do Og e perguntamos várias coisas sobre assuntos variádos,
+como:
 
 -  como ele ingressou no mundo do software livre;
 -  envolvimento junto à várias comunidades, incluindo a comunidade
@@ -65,3 +65,5 @@ Links
 -  **Subversion**: http://en.wikipedia.org/wiki/Subversion_(software)
 -  **Bitbucket**: https://bitbucket.org/
 -  **BillReminder**: http://billreminder.gnulinuxbrasil.org/
+
+.. _Og Maciel: http://www.ogmaciel.com

--- a/content/episodes/002-karlisson-bezerra-ilustrador.rst
+++ b/content/episodes/002-karlisson-bezerra-ilustrador.rst
@@ -5,10 +5,9 @@ Episódio 1: Karlisson Bezerra, Ilustrador
 :category: Podcast
 :podcast: https://archive.org/download/castalio-podcast-02/castalio-podcast-02.mp3
 
-Em um sábado ensolarado (aqui em North Carolina pelo menos, não sei em
-Natal ou São Paulo) tivemos o prazer de conversar com o **Karlisson
-Bezerra**, desenvolvedor web e ilustrador do famoso `Nerdson não vai à
-Escola <http://nerdson.com/blog/>`__.
+Em um sábado ensolarado (aqui em North Carolina pelo menos, não sei em Natal ou
+São Paulo) tivemos o prazer de conversar com o **Karlisson Bezerra**,
+desenvolvedor web e ilustrador do famoso `Nerdson não vai à Escola`_.
 
 .. figure:: {filename}/images/karlissonbezerra.jpg
    :alt: Sr. Tartaruga
@@ -28,7 +27,12 @@ Escute Agora
 
 Links
 -----
--  `Nerdson não vai à escola <http://nerdson.com/blog/>`__
--  `Inkscape <http://inkscape.org/>`__
--  `1001 Códigos Que Você Precisa Implementar Antes De Morrer <https://github.com/karlisson/1001>`__
+-  `Nerdson não vai à escola`_
+-  `Inkscape`_
+-  `1001 Códigos Que Você Precisa Implementar Antes De Morrer`_
 -  ... **e trocentos assuntos variados!**
+
+.. _Nerdson não vai à Escola: http://nerdson.com/blog/
+.. _Nerdson não vai à escola: http://nerdson.com/blog/
+.. _Inkscape: http://inkscape.org/
+.. _1001 Códigos Que Você Precisa Implementar Antes De Morrer: https://github.com/karlisson/1001

--- a/content/episodes/003-kurtkraut.rst
+++ b/content/episodes/003-kurtkraut.rst
@@ -33,16 +33,31 @@ Escute Agora
 
 Links
 -----
--  `BRASnet <http://www.wordiq.com/definition/BRASnet>`__
--  `IRC <https://secure.wikimedia.org/wikipedia/pt/wiki/Internet_Relay_Chat>`__
--  `LaTex <https://secure.wikimedia.org/wikipedia/pt/wiki/Latex>`__
--  `Mercurial <https://secure.wikimedia.org/wikipedia/pt/wiki/Mercurial>`__
--  `Mandriva <https://secure.wikimedia.org/wikipedia/pt/wiki/Mandriva>`__
--  **Livro:** "`Rework <http://www.amazon.com/Rework-Jason-Fried/dp/0307463745/ref=sr_1_1?ie=UTF8&qid=1299937824&sr=8-1>`__\ " por **Jason Fried**
--  **Livro:** `"On the Origin of Species" <http://www.amazon.com/origin-species-ebook/dp/B002RKSV2U/ref=sr_1_1?ie=UTF8&m=AG56TWVU5XWC2&s=digital-text&qid=1299938416&sr=1-1>`__ por **Darwin**
--  **Filmes: \ `Koyaanisqatsi <http://pt.wikipedia.org/wiki/Koyaanisqatsi>`__, \ `Powaqqatsi <http://pt.wikipedia.org/wiki/Powaqqatsi>`__ e \ `Naqoyqatsi <http://pt.wikipedia.org/wiki/Naqoyqatsi>`__**
--  `TextoLivre.org <http://TextoLivre.org>`__
--  `UPX.com.br <http://UPX.com.br>`__
--  `37Signals <http://37signals.com/>`__
+-  `BRASnet`_
+-  `IRC`_
+-  `LaTex`_
+-  `Mercurial`_
+-  `Mandriva`_
+-  **Livro:** "`Rework`_\ " por **Jason Fried**
+-  **Livro:** `"On the Origin of Species"`_ por **Darwin**
+-  **Filmes: `Koyaanisqatsi`_, `Powaqqatsi`_ e `Naqoyqatsi`_**
+-  `TextoLivre.org`_
+-  `UPX.com.br`_
+-  `37Signals`_
 -  **Blog**: kurtkraut.net (Samara)
--  **Twitter**: `http://twitter.com/kurtkraut <http://twitter.com/#!/kurtkraut>`__
+-  **Twitter**: `@kurtkraut`_
+
+.. _BRASnet: http://www.wordiq.com/definition/BRASnet
+.. _IRC: https://secure.wikimedia.org/wikipedia/pt/wiki/Internet_Relay_Chat
+.. _LaTex: https://secure.wikimedia.org/wikipedia/pt/wiki/Latex
+.. _Mercurial: https://secure.wikimedia.org/wikipedia/pt/wiki/Mercurial
+.. _Mandriva: https://secure.wikimedia.org/wikipedia/pt/wiki/Mandriva
+.. _Rework: http://www.amazon.com/Rework-Jason-Fried/dp/0307463745/ref=sr_1_1?ie=UTF8&qid=1299937824&sr=8-1
+.. _"On the Origin of Species": http://www.amazon.com/origin-species-ebook/dp/B002RKSV2U/ref=sr_1_1?ie=UTF8&m=AG56TWVU5XWC2&s=digital-text&qid=1299938416&sr=1-1
+.. _Koyaanisqatsi: http://pt.wikipedia.org/wiki/Koyaanisqatsi
+.. _Powaqqatsi: http://pt.wikipedia.org/wiki/Powaqqatsi
+.. _Naqoyqatsi: http://pt.wikipedia.org/wiki/Naqoyqatsi
+.. _TextoLivre.org: http://TextoLivre.org
+.. _UPX.com.br: http://UPX.com.br
+.. _37Signals: http://37signals.com/
+.. _@kurtkraut: http://twitter.com/#!/kurtkraut

--- a/content/episodes/004-luciana-fujii-pontelo-gnome-women-outreach-program.rst
+++ b/content/episodes/004-luciana-fujii-pontelo-gnome-women-outreach-program.rst
@@ -29,14 +29,24 @@ Contato
 -------
 -  **Blog**: http://blog.fujii.eti.br
 -  **IRC**: **fujii** na freenode e gimpnet
--  **Identi.ca**: `Fujii <http://identi.ca/fujii>`__
+-  **Identi.ca**: `Fujii`_
 
 Links
 -----
--  `GNOME Women Outreach Program <https://live.gnome.org/GnomeWomen/OutreachProgram2010>`__
--  `Identi.ca <http://identi.ca/>`__
--  `FISL <http://fisl.softwarelivre.org/>`__
--  `CEFET <https://secure.wikimedia.org/wikipedia/pt/wiki/Anexo:Lista_de_Centros_Federais_de_Educa%C3%A7%C3%A3o_Tecnol%C3%B3gica>`__
--  `Conectiva Linux <https://secure.wikimedia.org/wikipedia/en/wiki/Conectiva>`__
--  `OpenCast Podcast <http://br-linux.org/2011/opencast-episodio-2-ubuntu/>`__
--  `Razec's Lab <http://razec.wordpress.com>`__
+-  `GNOME Women Outreach Program`_
+-  `Identi.ca`_
+-  `FISL`_
+-  `CEFET`_
+-  `Conectiva Linux`_
+-  `OpenCast Podcast`_
+-  `Razec's Lab`_
+
+
+.. _Fujii: http://identi.ca/fujii
+.. _GNOME Women Outreach Program: https://live.gnome.org/GnomeWomen/OutreachProgram2010
+.. _Identi.ca: http://identi.ca/
+.. _FISL: http://fisl.softwarelivre.org/
+.. _CEFET: https://secure.wikimedia.org/wikipedia/pt/wiki/Anexo:Lista_de_Centros_Federais_de_Educa%C3%A7%C3%A3o_Tecnol%C3%B3gica
+.. _Conectiva Linux: https://secure.wikimedia.org/wikipedia/en/wiki/Conectiva
+.. _OpenCast Podcast: http://br-linux.org/2011/opencast-episodio-2-ubuntu/
+.. _Razec's Lab: http://razec.wordpress.com

--- a/content/episodes/005-murilo-queiroz-em-busca-dos-tesouros.rst
+++ b/content/episodes/005-murilo-queiroz-em-busca-dos-tesouros.rst
@@ -25,7 +25,7 @@ Escute Agora
 
 Contato
 -------
--  **Blog**: `http://muriloq.com/blog <http://muriloq.com/>`__ e http://www.tecnologiainteligente.com.br/
+-  **Blog**: `http://muriloq.com/blog`_ e http://www.tecnologiainteligente.com.br/
 -  **Twitter**: http://twitter.com/#!/muriloq
 
 Links
@@ -33,10 +33,10 @@ Links
 -  **Em Busca dos Tesouros**, um jogo nacional muito sofisticado (para a
    eṕoca e para o hardware), feito por um adolescente de Recife, o
    **Tadeu Curinga da Silva**. A historia toda: http://muriloq.com/ebdt
--  `Pitfall <https://secure.wikimedia.org/wikipedia/pt/wiki/Pitfall!>`__
+-  `Pitfall`_
    no **Atari**
 -  Encontro com um dos maiores conhecedores do
-   `ZX-81 <https://secure.wikimedia.org/wikipedia/pt/wiki/Sinclair_ZX81>`__
+   `ZX-81`_
    do Brasil, **Kelly Murta: \ http://zx81.eu5.org/**
 
    -  **Fotos**:
@@ -44,11 +44,21 @@ Links
 
 -  **ColecoVision: \ http://colecovisionzone.com/**
 -  **Eduardo Melo**: http://opcodegames.com/
--  **Filme**: `Black Swan <http://www.amazon.com/Black-Swan-Natalie-Portman/dp/B0041KKYEM/ref=sr_1_1?ie=UTF8&qid=1302915311&sr=8-1>`__
--  **Filme**: `Perfect Blue <http://www.amazon.com/Perfect-Blue-Junko-Iwao/dp/B00000JL42/ref=sr_1_1?ie=UTF8&qid=1302915272&sr=8-1>`__
--  **Livro**: `A Games of Thrones (Song of Ice and Fire) <http://www.amazon.com/Game-Thrones-Song-Ice-Fire/dp/0553386794/ref=sr_1_1?ie=UTF8&qid=1302915204&sr=8-1>`__ do **George R. R. Martin**
--  **Autor:** `Neil Gaiman <https://secure.wikimedia.org/wikipedia/pt/wiki/Neil_Gaiman>`__
--  **Livro**: `Daemon e Freedom (TM) <http://www.amazon.com/Freedom-TM-Daniel-Suarez/dp/0525951571/ref=sr_1_1?ie=UTF8&s=books&qid=1302915238&sr=8-1>`__ do **Daniel Suarez**
--  **Livro**: `You're Not a Gadget <http://www.amazon.com/You-Are-Not-Gadget-Manifesto/dp/0307389979/ref=sr_1_1?ie=UTF8&qid=1302915166&sr=8-1>`__ do **Jaron Lanier**
+-  **Filme**: `Black Swan`_
+-  **Filme**: `Perfect Blue`_
+-  **Livro**: `A Games of Thrones (Song of Ice and Fire)`_ do **George R. R. Martin**
+-  **Autor:** `Neil Gaiman`_
+-  **Livro**: `Daemon e Freedom (TM)`_ do **Daniel Suarez**
+-  **Livro**: `You're Not a Gadget`_ do **Jaron Lanier**
 -  **World Autism Awareness Day:** http://revistaautismo.com.br
 -  **Revista Espirito Livre**: http://espiritolivre.org/
+
+.. _http://muriloq.com/blog: http://muriloq.com/
+.. _Pitfall: https://secure.wikimedia.org/wikipedia/pt/wiki/Pitfall!
+.. _ZX-81: https://secure.wikimedia.org/wikipedia/pt/wiki/Sinclair_ZX81
+.. _Black Swan: http://www.amazon.com/Black-Swan-Natalie-Portman/dp/B0041KKYEM/ref=sr_1_1?ie=UTF8&qid=1302915311&sr=8-1
+.. _Perfect Blue: http://www.amazon.com/Perfect-Blue-Junko-Iwao/dp/B00000JL42/ref=sr_1_1?ie=UTF8&qid=1302915272&sr=8-1
+.. _A Games of Thrones (Song of Ice and Fire): http://www.amazon.com/Game-Thrones-Song-Ice-Fire/dp/0553386794/ref=sr_1_1?ie=UTF8&qid=1302915204&sr=8-1
+.. _Neil Gaiman: https://secure.wikimedia.org/wikipedia/pt/wiki/Neil_Gaiman
+.. _Daemon e Freedom (TM): http://www.amazon.com/Freedom-TM-Daniel-Suarez/dp/0525951571/ref=sr_1_1?ie=UTF8&s=books&qid=1302915238&sr=8-1
+.. _You're Not a Gadget: http://www.amazon.com/You-Are-Not-Gadget-Manifesto/dp/0307389979/ref=sr_1_1?ie=UTF8&qid=1302915166&sr=8-1

--- a/content/episodes/006-diego-burigo-zacarao-projeto-transifex.rst
+++ b/content/episodes/006-diego-burigo-zacarao-projeto-transifex.rst
@@ -10,21 +10,17 @@ Diego Búrigo Zacarão - Projeto Transifex
 
    Transifex
 
-Neste episódio, depois de semanas de muito suor, sangue e lágrimas
-(todas minhas, te garanto), consegui finalmente raptar o `Diego Búrigo
-Zacarão <http://diegobz.net/>`__, desenvolvedor líder do projeto
-`Transifex <http://transifex.net>`__, uma ferramente que nasceu durante
-uma das edições do `Google Summer of
-Code <https://code.google.com/soc/>`__. Durante nosso bate-papo o
-**Diego** explica como que ele, um garoto que preferia brincar na rua e
-bater bola, veio a aprender a gostar de computadores, entrou no projeto
-Fedora e hoje é membro do **Fedora Localization Project Steering
-Committee** – **FLSCo** e do **Fedora Localization Infrastructure
-Team**. Além de discutirmos sobre os benefícions e como que
-o \ `Transifex <http://transifex.net>`__ funciona, o Diego também nos
-conta sobre o período que ele passou "encarcerado" na **Grécia**
-trabalhando no `Google Summer of Code <https://code.google.com/soc/>`__,
-e o que fazer "quando a água bate na bunda"! ;)
+Neste episódio, depois de semanas de muito suor, sangue e lágrimas (todas
+minhas, te garanto), consegui finalmente raptar o `Diego Búrigo Zacarão`_,
+desenvolvedor líder do projeto `Transifex`_, uma ferramente que nasceu durante
+uma das edições do `Google Summer of Code`_. Durante nosso bate-papo
+o **Diego** explica como que ele, um garoto que preferia brincar na rua e bater
+bola, veio a aprender a gostar de computadores, entrou no projeto Fedora e hoje
+é membro do **Fedora Localization Project Steering Committee** – **FLSCo** e do
+**Fedora Localization Infrastructure Team**. Além de discutirmos sobre os
+benefícions e como que o \ `Transifex`_ funciona, o Diego também nos conta
+sobre o período que ele passou "encarcerado" na **Grécia** trabalhando no
+`Google Summer of Code`_, e o que fazer "quando a água bate na bunda"! ;)
 
 Caso você não tenha interesse em traduções de software, pula para o
 minuto 30 e escuta o resto. Eu realmente recomendo este episódio por ser
@@ -44,21 +40,34 @@ Contato
 -  **Blog**: ﻿http://diegobz.net/
 -  **Twitter**: http://twitter.com/diegobz
 
-Alguns dados interessantes do `Transifex <http://transifex.net>`__:
+Alguns dados interessantes do `Transifex`_:
 
 -  Mais de **6,000 usuários** registrados
 -  **261 idiomas** representados
 -  **1,336 projetos** sendo traduzidos, dentre eles:
 
-   -  `Fedora <http://fedoraproject.org/>`__
-   -  `Meego <http://meego.com/>`__
-   -  `Bitbucket <https://bitbucket.org/>`__
-   -  `Django <http://www.djangoproject.com/>`__
+   -  `Fedora`_
+   -  `Meego`_
+   -  `Bitbucket`_
+   -  `Django`_
 
 Links
 -----
--  `Conectiva <https://secure.wikimedia.org/wikipedia/en/wiki/Conectiva>`__
--  `Fedora Brasil <http://www.projetofedora.org/>`__
--  `FISL <http://softwarelivre.org/fisl11/english/news>`__
--  `Indifex <http://www.indifex.com/>`__
--  **Livro**: `Digital Fortress <http://www.amazon.com/Digital-Fortress-Thriller-Dan-Brown/dp/0312944926/ref=sr_1_1?ie=UTF8&qid=1304171005&sr=8-1>`__ por **Dan Brown**
+-  `Conectiva`_
+-  `Fedora Brasil`_
+-  `FISL`_
+-  `Indifex`_
+-  **Livro**: `Digital Fortress`_ por **Dan Brown**
+
+.. _Bitbucket: https://bitbucket.org/
+.. _Conectiva: https://secure.wikimedia.org/wikipedia/en/wiki/Conectiva
+.. _Diego Búrigo Zacarão: http://diegobz.net/
+.. _Digital Fortress: http://www.amazon.com/Digital-Fortress-Thriller-Dan-Brown/dp/0312944926/ref=sr_1_1?ie=UTF8&qid=1304171005&sr=8-1
+.. _Django: http://www.djangoproject.com/
+.. _Fedora Brasil: http://www.projetofedora.org/
+.. _Fedora: http://fedoraproject.org/
+.. _FISL: http://softwarelivre.org/fisl11/english/news
+.. _Google Summer of Code: https://code.google.com/soc/
+.. _Indifex: http://www.indifex.com/
+.. _Meego: http://meego.com/
+.. _Transifex: http://transifex.net

--- a/content/episodes/007-frederico-goncalves-guimaraes-software-livre-educacional.rst
+++ b/content/episodes/007-frederico-goncalves-guimaraes-software-livre-educacional.rst
@@ -11,7 +11,7 @@ Frederico Gonçalves Guimaraes - Software Livre Educacional
    Frederico Gonçalves Guimaraes
 
 Neste episódio conversei com o **Frederico Gonçalves Guimaraes** do
-projeto `Software Livre Educacional <http://sleducacional.org/>`__, que
+projeto `Software Livre Educacional`_, que
 tem como objetivo principal organizar documentação e traduzir softwares
 livres que possam ser utilizados por educadores. Durante nosso bate-papo
 o Frederico me explica o quanto é importante difundir o software livre
@@ -56,4 +56,9 @@ Top 5
 
 Links
 -----
--  Tradutor do `Claws Mail <http://claws-mail.org>`__, `GCompris <http://gcompris.net>`__, `TuxPaint <http://tuxpaint.org>`__
+-  Tradutor do `Claws Mail`_, `GCompris`_, `TuxPaint`_
+
+.. _Software Livre Educacional: http://sleducacional.org/
+.. _Claws Mail: http://claws-mail.org
+.. _GCompris: http://gcompris.net
+.. _TuxPaint: http://tuxpaint.org

--- a/content/episodes/009-johan-dahlin-stoq-gestor-comercial-livre.rst
+++ b/content/episodes/009-johan-dahlin-stoq-gestor-comercial-livre.rst
@@ -11,17 +11,14 @@ Johan Dahlin - Stoq: Gestor Comercial Livre
 
    Johan Dahlin - Stoq: Gestor Comercial Livre
 
-Hoje o meu convidado é o `Johan Dahlin <blogs.gnome.org/johan>`__, um
-dos programadores do mundo do software livre  que eu mais admiro! O
-Johan nasceu na **Suécia** mas mora no Brasil desde 2004. No currículo
-dele temos participações em várias companhias de nome no mundo do
-software livre, como a `Fluendo <http://www.fluendo.com/>`__,
-`Litl <http://litl.com/>`__, e a `Async <http://www.async.com.br/>`__
-onde ele hoje trabalha e é um dos sócios. Neste episódio conversamos
-sobre como a adaptação Suécia - Brasil, sua primeira contribuição com
-software livre, vários de seus projetos como o
-`Stoq <http://www.stoq.com.br/pt-br>`__, um software de gestão comercial
-livre, e é claro que não podia faltar o top 5!
+Hoje o meu convidado é o `Johan Dahlin`_, um dos programadores do mundo do
+software livre  que eu mais admiro! O Johan nasceu na **Suécia** mas mora no
+Brasil desde 2004. No currículo dele temos participações em várias companhias
+de nome no mundo do software livre, como a `Fluendo`_, `Litl`_, e a `Async`_
+onde ele hoje trabalha e é um dos sócios. Neste episódio conversamos sobre como
+a adaptação Suécia - Brasil, sua primeira contribuição com software livre,
+vários de seus projetos como o `Stoq`_, um software de gestão comercial livre,
+e é claro que não podia faltar o top 5!
 
 Escute Agora
 ------------
@@ -30,8 +27,8 @@ Escute Agora
 
 Contato
 -------
-- **Twitter**: `twitter.com/johandahlin <http://twitter.com/#!/johandahlin>`__
-- **Blog**: `blogs.gnome.org/johan <http://blogs.gnome.org/johan/>`__
+- **Twitter**: `twitter.com/johandahlin`_
+- **Blog**: `blogs.gnome.org/johan`_
 
 Top 5
 -----
@@ -55,3 +52,12 @@ Top 5
 Links
 -----
 -  Goleiro da equipe **Malmö FF** da Suecia: https://secure.wikimedia.org/wikipedia/en/wiki/Johan\_Dahlin?
+
+
+.. _Async: http://www.async.com.br/
+.. _blogs.gnome.org/johan: http://blogs.gnome.org/johan/
+.. _Fluendo: http://www.fluendo.com/
+.. _Johan Dahlin: blogs.gnome.org/johan
+.. _Litl: http://litl.com/
+.. _Stoq: http://www.stoq.com.br/pt-br
+.. _twitter.com/johandahlin: http://twitter.com/#!/johandahlin

--- a/content/episodes/010-lucas-rocha-the-board-parte-1.rst
+++ b/content/episodes/010-lucas-rocha-the-board-parte-1.rst
@@ -52,19 +52,33 @@ Resumo
 
 Links
 -----
--  `Universidade Federal da Bahia <http://www.ufba.br/>`__
--  `PHP <http://www.php.net/>`__
--  `Projeto Software Livre Bahia (PSL-BA) <http://wiki.dcc.ufba.br/bin/view/PSL>`__
--  `Zenity <http://live.gnome.org/Zenity>`__
--  `GNOME <http://gnome.org>`__
--  `Nokia <http://www.nokia.com/>`__
--  `Maemo <http://www.maemo.org/>`__
--  `Litl <http://litl.com/>`__
--  `OpenSolaris <http://www.opensolaris.com/>`__
--  `Eye of GNOME <http://www.gnome.org/projects/eog/>`__
--  `Revista Espírito Livre <http://www.revista.espiritolivre.org/>`__
+-  `Universidade Federal da Bahia`_
+-  `PHP`_
+-  `Projeto Software Livre Bahia (PSL-BA)`_
+-  `Zenity`_
+-  `GNOME`_
+-  `Nokia`_
+-  `Maemo`_
+-  `Litl`_
+-  `OpenSolaris`_
+-  `Eye of GNOME`_
+-  `Revista Espírito Livre`_
 
 **Notas**: Eu gostaria de agradecer os comentários que eu recebi aqui no
 web site e também por e-mail, etc. Especialmente, gostaria de agradecer
-o `Aurélio Heckert <http://softwarelivre.org/aurium>`__ pela tonelada de
+o `Aurélio Heckert`_ pela tonelada de
 feedback que ele me enviou depois de escutar o último episódio! :)
+
+
+.. _Aurélio Heckert: http://softwarelivre.org/aurium
+.. _Eye of GNOME: http://www.gnome.org/projects/eog/
+.. _GNOME: http://gnome.org
+.. _Litl: http://litl.com/
+.. _Maemo: http://www.maemo.org/
+.. _Nokia: http://www.nokia.com/
+.. _OpenSolaris: http://www.opensolaris.com/
+.. _PHP: http://www.php.net/
+.. _Projeto Software Livre Bahia (PSL-BA): http://wiki.dcc.ufba.br/bin/view/PSL
+.. _Revista Espírito Livre: http://www.revista.espiritolivre.org/
+.. _Universidade Federal da Bahia: http://www.ufba.br/
+.. _Zenity: http://live.gnome.org/Zenity

--- a/content/episodes/011-lucas-rocha-the-board-parte-2.rst
+++ b/content/episodes/011-lucas-rocha-the-board-parte-2.rst
@@ -20,8 +20,7 @@ seu projeto **The Board**, o fator "cool" do **javascript**,
 **Agatha Christie**, **MacGyver** e um monte de coisas interessantes!
 
 Ah, antes que me esqueça, agora você já pode acompanhar o **Castálio
-Podcast** pelo `iTunes
-Store <http://itunes.apple.com/us/podcast/castalio-podcast/id446259197>`__!
+Podcast** pelo `iTunes Store`_!
 
 Escute Agora
 ------------
@@ -50,31 +49,60 @@ Resumo
 
 Top 5
 -----
--  **Música**: `John Coltrane <https://secure.wikimedia.org/wikipedia/en/wiki/John_coltrane>`__ (`A Love Supreme <http://www.amazon.com/Love-Supreme-John-Coltrane/dp/B0000A118M/ref=sr_1_1?ie=UTF8&qid=1309220869&sr=8-1>`__)
--  **Música**: `Miles Davis <https://secure.wikimedia.org/wikipedia/en/wiki/Miles_davis>`__ (`Kind of Blue <http://www.amazon.com/Kind-Of-Blue/dp/B00136JQMI/ref=sr_1_1?ie=UTF8&qid=1309221007&sr=8-1>`__)
+-  **Música**: `John Coltrane`_ (`A Love Supreme`_)
+-  **Música**: `Miles Davis`_ (`Kind of Blue`_)
 -  **Livros**: **Agatha Chistie**
--  **Livros**: `The Hacker Ethic <http://www.amazon.com/Hacker-Ethic-Pekka-Himanen/dp/037575878X/ref=sr_1_1?ie=UTF8&qid=1309220775&sr=8-1>`__ por **Pekka Himanen**
--  **Livros**: `The Design of Everyday Things <http://www.amazon.com/Design-Everyday-Things-Donald-Norman/dp/0465067107/ref=sr_1_1?ie=UTF8&qid=1309220669&sr=8-1>`__ por **Donald A. Norman**
--  **Livros**: `Melancholy Death of Oyster Boy and Other Stories <http://www.amazon.com/Melancholy-Death-Oyster-Other-Stories/dp/0060526491/ref=sr_1_4?ie=UTF8&qid=1309220636&sr=8-4>`__ por **Tim Burton**
--  **Livros**: `Rework <http://www.amazon.com/Rework-Jason-Fried/dp/0307463745/ref=sr_1_1?ie=UTF8&qid=1309219021&sr=8-1>`__ por **Jason Fried**
--  **Filme e Televisão**: `MacGyver <https://secure.wikimedia.org/wikipedia/en/wiki/MacGyver>`__
--  **Filme e Televisão**: `The Matrix <http://www.imdb.com/title/tt0133093/>`__
--  **Filme e Televisão**: `Beleza Americana <http://www.imdb.com/title/tt0169547/>`__
--  **Filme e Televisão**: `Cinema Paradiso <http://www.imdb.com/title/tt0095765/>`__
--  **Pessoas e Blogs**: `Havoc Pennington <http://blog.ometer.com/>`__
--  **Pessoas e Blogs**: `Vincent Untz <http://www.vuntz.net/journal/>`__
+-  **Livros**: `The Hacker Ethic`_ por **Pekka Himanen**
+-  **Livros**: `The Design of Everyday Things`_ por **Donald A. Norman**
+-  **Livros**: `Melancholy Death of Oyster Boy and Other Stories`_ por **Tim Burton**
+-  **Livros**: `Rework`_ por **Jason Fried**
+-  **Filme e Televisão**: `MacGyver`_
+-  **Filme e Televisão**: `The Matrix`_
+-  **Filme e Televisão**: `Beleza Americana`_
+-  **Filme e Televisão**: `Cinema Paradiso`_
+-  **Pessoas e Blogs**: `Havoc Pennington`_
+-  **Pessoas e Blogs**: `Vincent Untz`_
 
 Links
 -----
--  `Ikea <http://www.ikea.com/>`__
--  `The Board <https://live.gnome.org/TheBoardProject>`__
--  `GUADEC <http://www.desktopsummit.org/>`__
--  `Plasma <https://secure.wikimedia.org/wikipedia/en/wiki/KDE_Plasma_Workspaces>`__
--  `Litl <http://litl.com/>`__
--  `GJs <http://live.gnome.org/Gjs>`__
--  `Clutter <http://live.gnome.org/Clutter>`__
--  `GStreamer <https://secure.wikimedia.org/wikipedia/en/wiki/GStreamer>`__
--  `jQuery <http://jquery.com/>`__
--  `Node.js <http://nodejs.org/>`__
--  `MongoDB <http://www.mongodb.org/>`__
--  `CoffeeScript <http://coffeescript.org/>`__
+-  `Ikea`_
+-  `The Board`_
+-  `GUADEC`_
+-  `Plasma`_
+-  `Litl`_
+-  `GJs`_
+-  `Clutter`_
+-  `GStreamer`_
+-  `jQuery`_
+-  `Node.js`_
+-  `MongoDB`_
+-  `CoffeeScript`_
+
+
+.. _A Love Supreme: http://www.amazon.com/Love-Supreme-John-Coltrane/dp/B0000A118M/ref=sr_1_1?ie=UTF8&qid=1309220869&sr=8-1
+.. _Beleza Americana: http://www.imdb.com/title/tt0169547/
+.. _Cinema Paradiso: http://www.imdb.com/title/tt0095765/
+.. _Clutter: http://live.gnome.org/Clutter
+.. _CoffeeScript: http://coffeescript.org/
+.. _GJs: http://live.gnome.org/Gjs
+.. _GStreamer: https://secure.wikimedia.org/wikipedia/en/wiki/GStreamer
+.. _GUADEC: http://www.desktopsummit.org/
+.. _Havoc Pennington: http://blog.ometer.com/
+.. _Ikea: http://www.ikea.com/
+.. _iTunes Store: http://itunes.apple.com/us/podcast/castalio-podcast/id446259197
+.. _John Coltrane: https://secure.wikimedia.org/wikipedia/en/wiki/John_coltrane
+.. _jQuery: http://jquery.com/
+.. _Kind of Blue: http://www.amazon.com/Kind-Of-Blue/dp/B00136JQMI/ref=sr_1_1?ie=UTF8&qid=1309221007&sr=8-1
+.. _Litl: http://litl.com/
+.. _MacGyver: https://secure.wikimedia.org/wikipedia/en/wiki/MacGyver
+.. _Melancholy Death of Oyster Boy and Other Stories: http://www.amazon.com/Melancholy-Death-Oyster-Other-Stories/dp/0060526491/ref=sr_1_4?ie=UTF8&qid=1309220636&sr=8-4
+.. _Miles Davis: https://secure.wikimedia.org/wikipedia/en/wiki/Miles_davis
+.. _MongoDB: http://www.mongodb.org/
+.. _Node.js: http://nodejs.org/
+.. _Plasma: https://secure.wikimedia.org/wikipedia/en/wiki/KDE_Plasma_Workspaces
+.. _Rework: http://www.amazon.com/Rework-Jason-Fried/dp/0307463745/ref=sr_1_1?ie=UTF8&qid=1309219021&sr=8-1
+.. _The Board: https://live.gnome.org/TheBoardProject
+.. _The Design of Everyday Things: http://www.amazon.com/Design-Everyday-Things-Donald-Norman/dp/0465067107/ref=sr_1_1?ie=UTF8&qid=1309220669&sr=8-1
+.. _The Hacker Ethic: http://www.amazon.com/Hacker-Ethic-Pekka-Himanen/dp/037575878X/ref=sr_1_1?ie=UTF8&qid=1309220775&sr=8-1
+.. _The Matrix: http://www.imdb.com/title/tt0133093/
+.. _Vincent Untz: http://www.vuntz.net/journal/

--- a/content/episodes/012-igor-pires-soares-projeto-fedora.rst
+++ b/content/episodes/012-igor-pires-soares-projeto-fedora.rst
@@ -73,13 +73,22 @@ Top 5
 -  **Televisão/Filmes**: Toy Story
 -  **Livros**: Quadrinhos e revistas de informática
 -  **Livros**: José Saramago
--  **Pessoas/Sites**: `BR-Linux <http://br-linux.org/>`__
--  **Pessoas/Sites**: Blog do `Diego Búrigo Zacarão <http://diegobz.net/>`__
--  **Pessoas/Sites**: `OS News <http://www.osnews.com/>`__
--  **Pessoas/Sites**: `Linux Forums <http://www.linuxforums.org/>`__
+-  **Pessoas/Sites**: `BR-Linux`_
+-  **Pessoas/Sites**: Blog do `Diego Búrigo Zacarão`_
+-  **Pessoas/Sites**: `OS News`_
+-  **Pessoas/Sites**: `Linux Forums`_
 
 Links
 -----
--  `Transifex <http://transifex.net>`__
--  `Smolt <https://secure.wikimedia.org/wikipedia/en/wiki/Smolt_(Linux)>`__ (sistema de pesquisas de hardware)
--  `FUDCon <http://fedoraproject.org/wiki/FUDCon>`__
+-  `Transifex`_
+-  `Smolt`_ (sistema de pesquisas de hardware)
+-  `FUDCon`_
+
+
+.. _BR-Linux: http://br-linux.org/
+.. _Diego Búrigo Zacarão: http://diegobz.net/
+.. _OS News: http://www.osnews.com/
+.. _Linux Forums: http://www.linuxforums.org/
+.. _Transifex: http://transifex.net
+.. _Smolt: https://secure.wikimedia.org/wikipedia/en/wiki/Smolt_(Linux)
+.. _FUDCon: http://fedoraproject.org/wiki/FUDCon

--- a/content/episodes/013-aline-duarte-bessa-accerciser.rst
+++ b/content/episodes/013-aline-duarte-bessa-accerciser.rst
@@ -12,8 +12,7 @@ Aline Duarte Bessa - Accerciser
    Aline Duarte Bessa - Accerciser
 
 Neste episódio bato um papo com a **Aline Duarte Bessa**, mais uma
-Brasileira que está participando do `GNOME Women Outreach
-Program <http://live.gnome.org/GnomeWomen/OutreachProgram2011>`__
+Brasileira que está participando do `GNOME Women Outreach Program`_
 (**GWOP**). Mesmo com um pouco de febre, gripe, e problemas técnicos com
 2 de seus computadores, ela tirou um pouco do seu tempo para me contar
 como que ela está atualizando a documentação do Accerciser para
@@ -22,7 +21,7 @@ o que o Accerciser é:
 
     "O Accerciser é um explorador interativo de acessibilidade para o
     ambiente GNOME. Escrito em Python, ele utiliza o
-    `AT-SPI <http://directory.fsf.org/at-spi.html>`__ para inspecionar e
+    `AT-SPI`_ para inspecionar e
     controlar widgets, permitindo que você verifique se um aplicativo
     está fornecendo informações corretas para as tecnologias assistivas
     e frameworks para testes automatizados. O Accerciser possui um
@@ -71,28 +70,48 @@ Top 5
 -  **Música**: Bloody Valentine
 -  **Música**: Velvet Underground
 -  **Música**: David Bowie
--  **Livro**: **On The Road** por \ `Jack Kerouac <http://www.amazon.com/Jack-Kerouac/e/B000APV9LY/ref=sr_ntt_srch_lnk_1?qid=1310835590&sr=8-1>`__
--  **Livro**: **The Corrections** e **Freedom** por \ `Jonathan Franzen <http://www.amazon.com/Jonathan-Franzen/e/B00458HQ7S/ref=sr_ntt_srch_lnk_1?qid=1310835694&sr=8-1>`__
--  **Livro**: **Cem Anos de Solidão** por `Gabriel Garcia Marquez <http://www.amazon.com/Gabriel-Garcia-Marquez/e/B000AQ1JWC/ref=sr_ntt_srch_lnk_1?qid=1310835752&sr=8-1>`__
+-  **Livro**: **On The Road** por \ `Jack Kerouac`_
+-  **Livro**: **The Corrections** e **Freedom** por \ `Jonathan Franzen`_
+-  **Livro**: **Cem Anos de Solidão** por `Gabriel Garcia Marquez`_
 -  **Livro**: **O Jogo da Amarelinha** por \ **Julio Cortazar** and
    **Fernando de Castro Ferro**
--  **Livro**: **To the Light House** por `Virginia Woolf <http://www.amazon.com/Virginia-Woolf/e/B000AQ1T7W/ref=sr_ntt_srch_lnk_1?qid=1310835868&sr=8-1>`__
--  **Filme**: A Dupla Vida de Veronique do \ `Krzysztof Kieslowski <http://www.imdb.com/name/nm0001425/>`__
+-  **Livro**: **To the Light House** por `Virginia Woolf`_
+-  **Filme**: A Dupla Vida de Veronique do \ `Krzysztof Kieslowski`_
 -  **Filme**: O Poderoso Chefão (trilogia)
 -  **Filme** : Matrix (trilogia)
 -  **Filme**: De Volta Para o Futuro (trilogia)
--  **Filmes**: Curtindo a Vida a Doidado e outros filmes do `John Hughes <http://www.imdb.com/name/nm0000455/>`__
--  **Pessoas/Web Site**: `Já Matei Por Menos e Já Escrevi Por Mais <http://mateipormenos.blogspot.com/>`__ da **Juliana Cunha**
--  **Pessoas/Web Site**: `XKCD <http://xkcd.com/>`__
--  **Pessoas/Web Site**: `Fiction Press <http://www.fictionpress.com/>`__
+-  **Filmes**: Curtindo a Vida a Doidado e outros filmes do `John Hughes`_
+-  **Pessoas/Web Site**: `Já Matei Por Menos e Já Escrevi Por Mais`_ da **Juliana Cunha**
+-  **Pessoas/Web Site**: `XKCD`_
+-  **Pessoas/Web Site**: `Fiction Press`_
 
 Links
 -----
--  `Accerciser <http://live.gnome.org/Accerciser>`__
--  `Orca <http://live.gnome.org/Orca>`__
--  `Rails <http://rubyonrails.org/>`__
--  `Colivre <http://colivre.coop.br/>`__
--  `Revista Espírito Livre <http://www.revista.espiritolivre.org/>`__
--  `HackToons <http://hacktoon.com/>`__
+-  `Accerciser`_
+-  `Orca`_
+-  `Rails`_
+-  `Colivre`_
+-  `Revista Espírito Livre`_
+-  `HackToons`_
 
-E não se esqueça de votar no \ `Castálio <http://premiofrida.org/por/projects/view/1424>`__ para o **Prêmio Frida**!
+E não se esqueça de votar no `Castálio`_ para o **Prêmio Frida**!
+
+
+.. _GNOME Women Outreach Program: http://live.gnome.org/GnomeWomen/OutreachProgram2011
+.. _AT-SPI: http://directory.fsf.org/at-spi.html
+.. _Jack Kerouac: http://www.amazon.com/Jack-Kerouac/e/B000APV9LY/ref=sr_ntt_srch_lnk_1?qid=1310835590&sr=8-1
+.. _Jonathan Franzen: http://www.amazon.com/Jonathan-Franzen/e/B00458HQ7S/ref=sr_ntt_srch_lnk_1?qid=1310835694&sr=8-1
+.. _Gabriel Garcia Marquez: http://www.amazon.com/Gabriel-Garcia-Marquez/e/B000AQ1JWC/ref=sr_ntt_srch_lnk_1?qid=1310835752&sr=8-1
+.. _Virginia Woolf: http://www.amazon.com/Virginia-Woolf/e/B000AQ1T7W/ref=sr_ntt_srch_lnk_1?qid=1310835868&sr=8-1
+.. _Krzysztof Kieslowski: http://www.imdb.com/name/nm0001425/
+.. _John Hughes: http://www.imdb.com/name/nm0000455/
+.. _Já Matei Por Menos e Já Escrevi Por Mais: http://mateipormenos.blogspot.com/
+.. _XKCD: http://xkcd.com/
+.. _Fiction Press: http://www.fictionpress.com/
+.. _Accerciser: http://live.gnome.org/Accerciser
+.. _Orca: http://live.gnome.org/Orca
+.. _Rails: http://rubyonrails.org/
+.. _Colivre: http://colivre.coop.br/
+.. _Revista Espírito Livre: http://www.revista.espiritolivre.org/
+.. _HackToons: http://hacktoon.com/
+.. _Castálio: http://premiofrida.org/por/projects/view/1424

--- a/content/episodes/014-hugo-doria-arch-linux.rst
+++ b/content/episodes/014-hugo-doria-arch-linux.rst
@@ -11,17 +11,15 @@ Hugo Dória - Arch Linux
 
    Hugo Dória - Arch Linux
 
-O meu entrevistado de hoje é o `Hugo Dória <http://hdoria.com/>`__, que
-para mim foi por muito tempo sinônimo do `Arch
-Linux <http://www.archlinux.org/>`__ no Brasil. Durante nosso bate-papo
-conversamos sobre sua história pelo Arch, alguns dos seus projetos de
-segurança e alerta de atualizações, e como que ele deixou de querer ser
-um \ **hacker**, invadir a **NASA** e **FBI**, e acabou se
-especializando em segurança de sistemas! Também conversamos sobre a
-emoção de ser pai pela primeira vez, como que funciona o **Tribunal de
-Justiça de Sergipe**, o processo para iniciar a sua startup chamada
-`POPCode <http://www.popcode.com.br/>`__, gostando de música a partir do
-joguinho **Rock N' Roll Racing**, e é claro seu **Top 5**!!!
+O meu entrevistado de hoje é o `Hugo Dória`_, que para mim foi por muito tempo
+sinônimo do `Arch Linux`_ no Brasil. Durante nosso bate-papo conversamos sobre
+sua história pelo Arch, alguns dos seus projetos de segurança e alerta de
+atualizações, e como que ele deixou de querer ser um \ **hacker**, invadir
+a **NASA** e **FBI**, e acabou se especializando em segurança de sistemas!
+Também conversamos sobre a emoção de ser pai pela primeira vez, como que
+funciona o **Tribunal de Justiça de Sergipe**, o processo para iniciar a sua
+startup chamada `POPCode`_, gostando de música a partir do joguinho **Rock N'
+Roll Racing**, e é claro seu **Top 5**!!!
 
 Escute Agora
 ------------
@@ -74,13 +72,27 @@ Top 5
 -  **Filme**: Samurai X
 -  **Filmes**: Dragon Ball
 -  **Filmes**: Cavaleiros do Zodíaco
--  **Pessoas/Web Site**: agregador de notícias `Planeta GNU/Linux Brasil <http://planeta.gnulinuxbrasil.org/>`__
--  **Pessoas/Web Site**: `BR-Linux <http://br-linux.org/>`__, `BR-Mac <http://br-mac.org/>`__ do **Augusto Campos**
+-  **Pessoas/Web Site**: agregador de notícias `Planeta GNU/Linux Brasil`_
+-  **Pessoas/Web Site**: `BR-Linux`_, `BR-Mac`_ do **Augusto Campos**
 
 Links
 -----
--  `HnTool <http://code.google.com/p/hntool/>`__
--  `pacupdate <https://code.google.com/p/pacupdate/>`__
--  `Arch Sheriff <http://www.mail-archive.com/aur-general@archlinux.org/msg01001.html>`__
--  `POPCode <http://www.popcode.com.br/>`__ (`fotos <https://picasaweb.google.com/hugodoria/Popcode#>`__)
--  `Rock and Roll Racing <https://secure.wikimedia.org/wikipedia/pt/wiki/Rock_%26_Roll_Racing>`__
+-  `HnTool`_
+-  `pacupdate`_
+-  `Arch Sheriff`_
+-  `POPCode`_ (`fotos`_)
+-  `Rock and Roll Racing`_
+
+
+.. _Hugo Dória: http://hdoria.com/
+.. _Arch Linux: http://www.archlinux.org/
+.. _POPCode: http://www.popcode.com.br/
+.. _Planeta GNU/Linux Brasil: http://planeta.gnulinuxbrasil.org/
+.. _BR-Linux: http://br-linux.org/
+.. _HnTool: http://code.google.com/p/hntool/
+.. _BR-Mac: http://br-mac.org/
+.. _pacupdate: https://code.google.com/p/pacupdate/
+.. _Arch Sheriff: http://www.mail-archive.com/aur-general@archlinux.org/msg01001.html
+.. _POPCode: http://www.popcode.com.br/
+.. _Rock and Roll Racing: https://secure.wikimedia.org/wikipedia/pt/wiki/Rock_%26_Roll_Racing
+.. _fotos: https://picasaweb.google.com/hugodoria/Popcode#

--- a/content/episodes/015-carlos-ribeiro-radiotray.rst
+++ b/content/episodes/015-carlos-ribeiro-radiotray.rst
@@ -20,7 +20,7 @@ de livros técnicos em português em Portugal e o seu **Top 5**!
 
 No próximo episódio teremos o **Álvaro "Turicas" Justem** para conversar
 sobre **Arduino**! E não se esqueçam de nos acompanhar pelo
-`Twitter <https://twitter.com/#!/castaliopod>`__!
+`Twitter`_!
 
 Escute Agora
 ------------
@@ -59,33 +59,63 @@ Resumo
 
 Top 5
 -----
--  **Música**:  `U2 <http://www.last.fm/search?q=u2&from=ac>`__
--  **Música**:  `Cold Play <http://www.last.fm/search?q=cold+play&from=ac>`__
--  **Música**:  `Célia Cruz <http://www.last.fm/search?q=C%C3%A9lia+Cruz&from=ac>`__
--  **Música**:  `John Williams <http://www.last.fm/search?q=John+Williams&from=ac>`__
--  **Música**:  `Eminem <http://www.last.fm/search?q=eminem&from=ac>`__
--  **Livro**:  Livros do \ `Edgar Allan Poe <https://secure.wikimedia.org/wikipedia/en/wiki/Edgar_Allan_Poe>`__
--  **Livro**:  `War of The Worlds <http://www.amazon.com/War-Worlds-H-G-Wells/dp/1936594056/ref=sr_1_1?ie=UTF8&qid=1313959221&sr=8-1>`__ por `H. G.  Wells <https://secure.wikimedia.org/wikipedia/en/wiki/H._G._Wells>`__
--  **Livro**:  Livros do `J.R.R.  Tolkien <https://secure.wikimedia.org/wikipedia/en/wiki/J._R._R._Tolkien>`__
--  **Livro**:  `The Code Book: The Secret History of Codes and Code-breaking <http://www.amazon.co.uk/Code-Book-Secret-History-Code-breaking/dp/1857028899/ref=sr_1_1?ie=UTF8&qid=1313193191&sr=8-1>`__
--  **Livro**:  `The Code Book: The Science of Secrecy from Ancient Egypt to Quantum Cryptography <http://www.amazon.com/Code-Book-Science-Secrecy-Cryptography/dp/0385495323/ref=pd_sim_b_1>`__
--  **Livro**:  Livros do `Dan Brown <https://secure.wikimedia.org/wikipedia/en/wiki/Dan_brown>`__
--  **Filme**:  `Amélie <http://www.imdb.com/title/tt0211915/>`__
--  **Filme**: `Matrix <http://www.imdb.com/find?s=all&q=matrix>`__ (trilogia)
--  **Filme** :  `Pulp Fiction <http://www.imdb.com/find?s=all&q=Pulp+Fiction>`__
--  **Filme**:  `Senhor dos Anéis <http://www.imdb.com/find?s=all&q=Senhor+dos+An%E9is>`__ (trilogia)
--  **Filmes**:  `Indiana Jones <http://www.imdb.com/find?s=all&q=indiana+jones>`__ (série)
--  **Filmes**:  `Star Wars <http://www.imdb.com/find?s=all&q=star+wars>`__ (série)
--  **Pessoas/Web Site**: `DZone: Fresh Links for Developers <http://www.dzone.com/links/index.html>`__
--  **Pessoas/Web Site**:  `FS Daily: Free Software News <http://www.fsdaily.com/>`__
--  **Pessoas/Web Site**:  `The H: Security news and Open source developments <http://www.h-online.com/>`__
--  **Pessoas/Web Site**:  `Dilbert <http://www.dilbert.com/>`__
+-  **Música**:  `U2`_
+-  **Música**:  `Cold Play`_
+-  **Música**:  `Célia Cruz`_
+-  **Música**:  `John Williams`_
+-  **Música**:  `Eminem`_
+-  **Livro**:  Livros do \ `Edgar Allan Poe`_
+-  **Livro**:  `War of The Worlds`_ por `H. G.  Wells`_
+-  **Livro**:  Livros do `J.R.R.  Tolkien`_
+-  **Livro**:  `The Code Book - The Secret History of Codes and Code-breaking`_
+-  **Livro**:  `The Code Book - The Science of Secrecy from Ancient Egypt to Quantum Cryptography`_
+-  **Livro**:  Livros do `Dan Brown`_
+-  **Filme**:  `Amélie`_
+-  **Filme**: `Matrix`_ (trilogia)
+-  **Filme** :  `Pulp Fiction`_
+-  **Filme**:  `Senhor dos Anéis`_ (trilogia)
+-  **Filmes**:  `Indiana Jones`_ (série)
+-  **Filmes**:  `Star Wars`_ (série)
+-  **Pessoas/Web Site**: `DZone - Fresh Links for Developers`_
+-  **Pessoas/Web Site**:  `FS Daily - Free Software News`_
+-  **Pessoas/Web Site**:  `The H - Security news and Open source developments`_
+-  **Pessoas/Web Site**:  `Dilbert`_
 
 Links
 -----
--  **Mora em**: `Vila Nova de Gaia <http://www.flickr.com/photos/stewied/3107027239/>`__ em **Portugal**
--  **Trabalha**: `MULTICERT <http://www.multicert.com/>`__
--  **Projeto**: `Radio Tray <http://radiotray.sf.net/>`__
--  `Foresight Linux <http://foresightlinux.org>`__
--  `Google Alerts <http://www.google.com/alerts>`__
--  `LaTeX <http://www.latex-project.org/>`__
+-  **Mora em**: `Vila Nova de Gaia`_ em **Portugal**
+-  **Trabalha**: `MULTICERT`_
+-  **Projeto**: `Radio Tray`_
+-  `Foresight Linux`_
+-  `Google Alerts`_
+-  `LaTeX`_
+
+.. _Twitter: https://twitter.com/#!/castaliopod
+.. _U2: http://www.last.fm/search?q=u2&from=ac
+.. _Cold Play: http://www.last.fm/search?q=cold+play&from=ac
+.. _Célia Cruz: http://www.last.fm/search?q=C%C3%A9lia+Cruz&from=ac
+.. _John Williams: http://www.last.fm/search?q=John+Williams&from=ac
+.. _Eminem: http://www.last.fm/search?q=eminem&from=ac
+.. _Edgar Allan Poe: https://secure.wikimedia.org/wikipedia/en/wiki/Edgar_Allan_Poe
+.. _War of The Worlds: http://www.amazon.com/War-Worlds-H-G-Wells/dp/1936594056/ref=sr_1_1?ie=UTF8&qid=1313959221&sr=8-1
+.. _J.R.R.  Tolkien: https://secure.wikimedia.org/wikipedia/en/wiki/J._R._R._Tolkien
+.. _H. G.  Wells: https://secure.wikimedia.org/wikipedia/en/wiki/H._G._Wells
+.. _The Code Book - The Secret History of Codes and Code-breaking: http://www.amazon.co.uk/Code-Book-Secret-History-Code-breaking/dp/1857028899/ref=sr_1_1?ie=UTF8&qid=1313193191&sr=8-1
+.. _The Code Book - The Science of Secrecy from Ancient Egypt to Quantum Cryptography: http://www.amazon.com/Code-Book-Science-Secrecy-Cryptography/dp/0385495323/ref=pd_sim_b_1
+.. _Dan Brown: https://secure.wikimedia.org/wikipedia/en/wiki/Dan_brown
+.. _Amélie: http://www.imdb.com/title/tt0211915/
+.. _Matrix: http://www.imdb.com/find?s=all&q=matrix
+.. _Pulp Fiction: http://www.imdb.com/find?s=all&q=Pulp+Fiction
+.. _Senhor dos Anéis: http://www.imdb.com/find?s=all&q=Senhor+dos+An%E9is
+.. _Indiana Jones: http://www.imdb.com/find?s=all&q=indiana+jones
+.. _Star Wars: http://www.imdb.com/find?s=all&q=star+wars
+.. _DZone - Fresh Links for Developers: http://www.dzone.com/links/index.html
+.. _FS Daily -  Free Software News: http://www.fsdaily.com/
+.. _The H - Security news and Open source developments: http://www.h-online.com/
+.. _Dilbert: http://www.dilbert.com/
+.. _Vila Nova de Gaia: http://www.flickr.com/photos/stewied/3107027239/
+.. _MULTICERT: http://www.multicert.com/
+.. _Radio Tray: http://radiotray.sf.net/
+.. _Foresight Linux: http://foresightlinux.org
+.. _Google Alerts: http://www.google.com/alerts
+.. _LaTeX: http://www.latex-project.org/

--- a/content/episodes/016-alvaro-turicas-justen-arduino.rst
+++ b/content/episodes/016-alvaro-turicas-justen-arduino.rst
@@ -11,19 +11,17 @@
 
    Álvaro "Turicas" Justen - Arduino
 
-No episódio de hoje conversei com o **Álvaro "Turicas" Justen** sobre um
-monte de coisas relacionadas ao **Arduino**, e como usá-lo junto com
-vários outros adaptadores (**shields**) para fazer um monte de coisas
-bacanas, como **controlar a cor de um abajour pelo seu telefone
-Android** e usar uma **guitarra para jogar Frets on Fire**! Também
-falamos do **Turiquinhas**, o **carro controlado por luz** cheio de
-firulas que ele desenvolveu junto com uns amigos. Depois que terminamos
-a entrevista, ele também me contou sobre o
-`TweetLamp <http://GitHub.com/turicas/tweetlamp>`__, uma forma super
-interessante de controlar uma lâmpada pelo Twitter! É só mandar uma
-mensagem "lâmpada **on**" que o arduino liga a lâmpada, e "lâmpada
-**off**" para desligá-la! Falamos de sua participação no **FISL 2011**,
-sobre sua viagem à **Bolivia**, terminando com o seu **Top 5**!
+No episódio de hoje conversei com o **Álvaro "Turicas" Justen** sobre um monte
+de coisas relacionadas ao **Arduino**, e como usá-lo junto com vários outros
+adaptadores (**shields**) para fazer um monte de coisas bacanas, como
+**controlar a cor de um abajour pelo seu telefone Android** e usar uma
+**guitarra para jogar Frets on Fire**! Também falamos do **Turiquinhas**,
+o **carro controlado por luz** cheio de firulas que ele desenvolveu junto com
+uns amigos. Depois que terminamos a entrevista, ele também me contou sobre
+o `TweetLamp`_, uma forma super interessante de controlar uma lâmpada pelo
+Twitter! É só mandar uma mensagem "lâmpada **on**" que o arduino liga
+a lâmpada, e "lâmpada **off**" para desligá-la! Falamos de sua participação no
+**FISL 2011**, sobre sua viagem à **Bolivia**, terminando com o seu **Top 5**!
 
 Escute Agora
 ------------
@@ -60,42 +58,87 @@ Resumo
 
 Top 5
 -----
--  **Música**:  `Iron Maiden <http://www.last.fm/search?q=Iron+Maiden&from=ac>`__
--  **Música**:  `Guns and Roses <http://www.last.fm/search?q=Guns+and+Roses&from=ac>`__
--  **Música**:  `Nirvana <http://www.last.fm/search?q=Nirvana&from=ac>`__
--  **Música**:  `Pearl Jam <http://www.last.fm/search?q=Pearl+Jam&from=ac>`__
--  **Música**:  `Infected Mushroom <http://www.last.fm/search?q=Infected+Mushroom&from=ac>`__
--  **Livro**:  `Cálculo <http://www.amazon.com/Calculus-Howard-Anton/dp/0470647728/ref=ntt_at_ep_dpt_5>`__ por `Howard Anton <http://www.amazon.com/Howard-Anton/e/B001ILHF44/ref=sr_ntt_srch_lnk_3?qid=1315190908&sr=8-3>`__
--  **Livro**:  `Física <http://www.amazon.com/Physics-1-David-Halliday/dp/0471320579/ref=sr_1_1?ie=UTF8&qid=1315190770&sr=8-1>`__ por `David Halliday <http://www.amazon.com/David-Halliday/e/B001H6KGYG/ref=sr_ntt_srch_lnk_1?qid=1315190770&sr=8-1>`__ e `Robert Resnick <http://www.amazon.com/Robert-Resnick/e/B001H6MBWG/ref=sr_ntt_srch_lnk_1?qid=1315190770&sr=8-1>`__
--  **Livro**:  `O Guia do Mochileiro das Galáxias <http://www.amazon.com/Ultimate-Hitchhikers-Guide-Galaxy/dp/0345453743/ref=sr_1_1?s=books&ie=UTF8&qid=1315191056&sr=1-1>`__ por `Douglas Adams <http://www.amazon.com/Douglas-Adams/e/B000AQ2A84/ref=sr_ntt_srch_lnk_1?qid=1315191056&sr=1-1>`__
+-  **Música**:  `Iron Maiden`_
+-  **Música**:  `Guns and Roses`_
+-  **Música**:  `Nirvana`_
+-  **Música**:  `Pearl Jam`_
+-  **Música**:  `Infected Mushroom`_
+-  **Livro**:  `Cálculo`_ por `Howard Anton`_
+-  **Livro**:  `Física`_ por `David Halliday`_ e `Robert Resnick`_
+-  **Livro**:  `O Guia do Mochileiro das Galáxias`_ por `Douglas Adams`_
 -  **Livro**:  **Shell Script** por **Júlio Neves**
--  **Livro**:  `Making Things Talk <http://www.amazon.com/Making-Things-Talk-Practical-Connecting/dp/0596510519/ref=sr_1_1?s=books&ie=UTF8&qid=1315191215&sr=1-1>`__ por `Tom Igoe <http://www.amazon.com/Tom-Igoe/e/B001K8AUGU/ref=sr_ntt_srch_lnk_1?qid=1315191215&sr=1-1>`__
--  **Livro**:  `Getting Started With Arduino <http://www.amazon.com/Getting-Started-Arduino-Make-Projects/dp/0596155514/ref=sr_1_1?s=books&ie=UTF8&qid=1315191275&sr=1-1>`__ por `Massimo Banzi <http://www.amazon.com/Massimo-Banzi/e/B00355CV22/ref=sr_ntt_srch_lnk_1?qid=1315191273&sr=1-1>`__
--  **Filme**:  `Apollo 13 <http://www.imdb.com/title/tt1772240/>`__
--  **Filme**:  `Uma Mente Brilhante <http://www.imdb.com/title/tt0268978/>`__
--  **Filme** :  `Matrix <http://www.imdb.com/find?s=all&q=Matrix>`__ (trilogia)
--  **Filme**:  `Inception <http://www.imdb.com/title/tt1375666/>`__
--  **Filmes**:  `Potiche <http://www.imdb.com/title/tt1521848/>`__
--  **Filmes**:  `Iron Man <http://www.imdb.com/title/tt0371746/>`__
+-  **Livro**:  `Making Things Talk`_ por `Tom Igoe`_
+-  **Livro**:  `Getting Started With Arduino`_ por `Massimo Banzi`_
+-  **Filme**:  `Apollo 13`_
+-  **Filme**:  `Uma Mente Brilhante`_
+-  **Filme** :  `Matrix`_ (trilogia)
+-  **Filme**:  `Inception`_
+-  **Filmes**:  `Potiche`_
+-  **Filmes**:  `Iron Man`_
 
 Links
 -----
--  **Mora em**: `Niteroi <http://maps.google.com/maps?q=Niteroi+-+Rio+de+Janeiro,+Brazil&hl=en&sll=35.930614,-79.030686&sspn=0.014386,0.03283&vpsrc=0&t=h&z=12>`__ no **Rio de Janeiro**
--  `Curso de Arduino <http://CursoDeArduino.com.br/>`__
--  `Eagle <https://secure.wikimedia.org/wikipedia/en/wiki/Eagle_(program)>`__
--  `Brazuino <http://brasuino.holoscopio.com/>`__ do `Holoscópio <http://holoscopio.com/>`__
--  `QCAD <https://secure.wikimedia.org/wikipedia/en/wiki/QCad>`__
--  `Severino <http://arduino.cc/en/Main/ArduinoBoardSerialSingleSided3>`__
--  `Turiquinhas <http://www.justen.eng.br/Turiquinhas/>`__
--  `Web2Py <http://www.web2py.com/>`__
--  `Zope <http://zope2.zope.org/>`__
--  `Django <https://www.djangoproject.com/>`__
--  `Flask <http://flask.pocoo.org/>`__
--  `Bottle <http://bottlepy.org/docs/dev/>`__
--  `FISL <https://secure.wikimedia.org/wikipedia/en/wiki/F%C3%B3rum_Internacional_Software_Livre>`__
--  `Frets on Fire <http://fretsonfire.sourceforge.net/>`__
--  `Guitar Hero <http://www.guitarherogame.com/gh1/>`__
--  `Eu, Android <http://www.euandroid.com.br/>`__
--  `Tiny OS <http://www.tinyos.net/>`__
--  `ELua <http://www.eluaproject.net/>`__
--  `TweetLamp <http://GitHub.com/turicas/tweetlamp>`__
+-  **Mora em**: `Niteroi`_ no **Rio de Janeiro**
+-  `Curso de Arduino`_
+-  `Eagle`_
+-  `Brazuino`_ do `Holoscópio`_
+-  `QCAD`_
+-  `Severino`_
+-  `Turiquinhas`_
+-  `Web2Py`_
+-  `Zope`_
+-  `Django`_
+-  `Flask`_
+-  `Bottle`_
+-  `FISL`_
+-  `Frets on Fire`_
+-  `Guitar Hero`_
+-  `Eu, Android`_
+-  `Tiny OS`_
+-  `ELua`_
+-  `TweetLamp`_
+
+
+.. _TweetLamp: http://GitHub.com/turicas/tweetlamp
+.. _Iron Maiden: http://www.last.fm/search?q=Iron+Maiden&from=ac
+.. _Guns and Roses: http://www.last.fm/search?q=Guns+and+Roses&from=ac
+.. _Nirvana: http://www.last.fm/search?q=Nirvana&from=ac
+.. _Pearl Jam: http://www.last.fm/search?q=Pearl+Jam&from=ac
+.. _Infected Mushroom: http://www.last.fm/search?q=Infected+Mushroom&from=ac
+.. _Cálculo: http://www.amazon.com/Calculus-Howard-Anton/dp/0470647728/ref=ntt_at_ep_dpt_5
+.. _Howard Anton: http://www.amazon.com/Howard-Anton/e/B001ILHF44/ref=sr_ntt_srch_lnk_3?qid=1315190908&sr=8-3
+.. _Física: http://www.amazon.com/Physics-1-David-Halliday/dp/0471320579/ref=sr_1_1?ie=UTF8&qid=1315190770&sr=8-1
+.. _O Guia do Mochileiro das Galáxias: http://www.amazon.com/Ultimate-Hitchhikers-Guide-Galaxy/dp/0345453743/ref=sr_1_1?s=books&ie=UTF8&qid=1315191056&sr=1-1
+.. _Robert Resnick: http://www.amazon.com/Robert-Resnick/e/B001H6MBWG/ref=sr_ntt_srch_lnk_1?qid=1315190770&sr=8-1
+.. _David Halliday: http://www.amazon.com/David-Halliday/e/B001H6KGYG/ref=sr_ntt_srch_lnk_1?qid=1315190770&sr=8-1
+.. _Making Things Talk: http://www.amazon.com/Making-Things-Talk-Practical-Connecting/dp/0596510519/ref=sr_1_1?s=books&ie=UTF8&qid=1315191215&sr=1-1
+.. _Douglas Adams: http://www.amazon.com/Douglas-Adams/e/B000AQ2A84/ref=sr_ntt_srch_lnk_1?qid=1315191056&sr=1-1
+.. _Tom Igoe: http://www.amazon.com/Tom-Igoe/e/B001K8AUGU/ref=sr_ntt_srch_lnk_1?qid=1315191215&sr=1-1
+.. _Getting Started With Arduino: http://www.amazon.com/Getting-Started-Arduino-Make-Projects/dp/0596155514/ref=sr_1_1?s=books&ie=UTF8&qid=1315191275&sr=1-1
+.. _Massimo Banzi: http://www.amazon.com/Massimo-Banzi/e/B00355CV22/ref=sr_ntt_srch_lnk_1?qid=1315191273&sr=1-1
+.. _Apollo 13: http://www.imdb.com/title/tt1772240/
+.. _Uma Mente Brilhante: http://www.imdb.com/title/tt0268978/
+.. _Matrix: http://www.imdb.com/find?s=all&q=Matrix
+.. _Inception: http://www.imdb.com/title/tt1375666/
+.. _Potiche: http://www.imdb.com/title/tt1521848/
+.. _Iron Man: http://www.imdb.com/title/tt0371746/
+.. _Niteroi: http://maps.google.com/maps?q=Niteroi+-+Rio+de+Janeiro,+Brazil&hl=en&sll=35.930614,-79.030686&sspn=0.014386,0.03283&vpsrc=0&t=h&z=12
+.. _Curso de Arduino: http://CursoDeArduino.com.br/
+.. _Eagle: https://secure.wikimedia.org/wikipedia/en/wiki/Eagle_(program)
+.. _Brazuino: http://brasuino.holoscopio.com/
+.. _QCAD: https://secure.wikimedia.org/wikipedia/en/wiki/QCad
+.. _Holoscópio: http://holoscopio.com/
+.. _Severino: http://arduino.cc/en/Main/ArduinoBoardSerialSingleSided3
+.. _Turiquinhas: http://www.justen.eng.br/Turiquinhas/
+.. _Web2Py: http://www.web2py.com/
+.. _Zope: http://zope2.zope.org/
+.. _Django: https://www.djangoproject.com/
+.. _Flask: http://flask.pocoo.org/
+.. _Bottle: http://bottlepy.org/docs/dev/
+.. _FISL: https://secure.wikimedia.org/wikipedia/en/wiki/F%C3%B3rum_Internacional_Software_Livre
+.. _Frets on Fire: http://fretsonfire.sourceforge.net/
+.. _Guitar Hero: http://www.guitarherogame.com/gh1/
+.. _Eu, Android: http://www.euandroid.com.br/
+.. _Tiny OS: http://www.tinyos.net/
+.. _ELua: http://www.eluaproject.net/
+.. _TweetLamp: http://GitHub.com/turicas/tweetlamp

--- a/content/episodes/017-pete-savage-git-in-the-trenches-gitt.rst
+++ b/content/episodes/017-pete-savage-git-in-the-trenches-gitt.rst
@@ -27,20 +27,16 @@ Portuguese. When I asked my listeners if they would be interested in an
 episode in English with someone new and exciting, the answer was an
 overwhelming '**Yes**!'
 
-So for my very first episode in English I chose to interview a good
-friend of mine from several years: **Pete Savage**! During the next 58
-minutes we talked about how we first met through a **PyGtk** video he
-posted a while back during a **Linux User Group** meeting, how he first
-got involved with **Edubuntu**, and then moved on to several other
-projects such as **ProgBox** and **GeekDeck**, about the books that he's
-written including the reason for writing "**Emblem Divide**\ ", how much
-the **Japanese culture** plays a role in his daily life, and his **Top
-5** movies, books and movies! A transcript of this episode can be found
-`here <http://www.castalio.info/transcript-episode-17-pete-savage-git-in-the-trenches-gitt/>`__,
-as well as a
-`link <http://translate.google.com/translate?sl=auto&tl=pt&js=n&prev=_t&hl=en&ie=UTF-8&layout=2&eotf=1&u=http%3A%2F%2Fwww.castalio.info%2Ftranscript-episode-17-pete-savage-git-in-the-trenches-gitt%2F&act=url>`__
-where you can translate it into your native language via `Google
-Translate <http://translate.google.com/>`__.
+So for my very first episode in English I chose to interview a good friend of
+mine from several years: **Pete Savage**! During the next 58 minutes we talked
+about how we first met through a **PyGtk** video he posted a while back during
+a **Linux User Group** meeting, how he first got involved with **Edubuntu**,
+and then moved on to several other projects such as **ProgBox** and
+**GeekDeck**, about the books that he's written including the reason for
+writing "**Emblem Divide**\ ", how much the **Japanese culture** plays a role
+in his daily life, and his **Top 5** movies, books and movies! A transcript of
+this episode can be found `here`_, as well as a `link`_ where you can
+translate it into your native language via `Google Translate`_.
 
 I had a great time chatting with Pete and I hope you'll also enjoy
 learning a bit more about him through this episode!
@@ -74,41 +70,82 @@ Summary
 
 Top 5
 -----
--  **Music**:  `Lagwagon <http://www.last.fm/music/Lagwagon>`__
--  **Music**:  `Green Day <http://www.last.fm/music/Green+Day>`__
--  **Music**:  `Mike Oldfield <http://www.last.fm/music/Mike+Oldfield>`__
--  **Music**:  `J-Rock <http://duckduckgo.com/?q=!lastfm%20Top%2010%20J-Rock%20Songs>`__
--  **Music**:  `J-Pop <http://www.last.fm/tag/j-pop>`__
--  **Books**:  `Night Watch <http://www.amazon.com/s/ref=ntt_athr_dp_sr_1?_encoding=UTF8&sort=relevancerank&search-alias=books&field-author=Sergei%20Lukyanenko#/ref=nb_sb_ss_i_1_11?field-keywords=night+watch+sergei+lukyanenko&url=search-alias%3Dstripbooks&sprefix=night+watch&rh=n%3A283155%2Ck%3Anight+watch+sergei+lukyanenko>`__ series by `Sergei Lukyanenko <https://secure.wikimedia.org/wikipedia/en/wiki/Sergei_Lukyanenko>`__
--  **Website**:  `Slashdot <http://slashdot.org/>`__
--  \*\*\*\*Website\*\*\*\*:  `The Register <http://www.theregister.co.uk/>`__
--  \*\*\*\*Website\*\*\*\*:  `The Daily WTF <http://thedailywtf.com/>`__
--  **Movies**:  `Kamikaze Girls <http://www.imdb.com/title/tt0416220/>`__
--  **Movies**:  `Inception <http://www.imdb.com/title/tt1375666/>`__
--  **Movies**:  `The Prestige <http://www.imdb.com/title/tt0482571/>`__
+-  **Music**:  `Lagwagon`_
+-  **Music**:  `Green Day`_
+-  **Music**:  `Mike Oldfield`_
+-  **Music**:  `J-Rock`_
+-  **Music**:  `J-Pop`_
+-  **Books**:  `Night Watch`_ series by `Sergei Lukyanenko`_
+-  **Website**:  `Slashdot`_
+-  \*\*\*\*Website\*\*\*\*:  `The Register`_
+-  \*\*\*\*Website\*\*\*\*:  `The Daily WTF`_
+-  **Movies**:  `Kamikaze Girls`_
+-  **Movies**:  `Inception`_
+-  **Movies**:  `The Prestige`_
 
 Links
 -----
--  `Greater New Hampshire Linux User Group (NHLUG) <http://gnhlug.org/>`__
--  `"Building GUI applications with Python, Gtk and Glade" <http://video.google.com/videoplay?docid=5838951374743244232>`__
--  `PyGtk <http://www.pygtk.org/>`__
--  `Duck Duck Go <https://duckduckgo.com/?t=i>`__
--  `Official Ubuntu Book <https://www.amazon.com/Official-Ubuntu-Book-Benjamin-Mako/dp/0132435942?tag=duckduckgo-d-20>`__
--  `Edubuntu <http://www.edubuntu.org/>`__
--  `PHP <http://www.php.net/>`__
--  `Knoppix <http://www.knoppix.org/>`__
--  `BETT Show <https://secure.wikimedia.org/wikipedia/en/wiki/BETT>`__
--  `StarOffice <https://secure.wikimedia.org/wikipedia/en/wiki/StarOffice>`__
+-  `Greater New Hampshire Linux User Group (NHLUG)`_
+-  `"Building GUI applications with Python, Gtk and Glade"`_
+-  `PyGtk`_
+-  `Duck Duck Go`_
+-  `Official Ubuntu Book`_
+-  `Edubuntu`_
+-  `PHP`_
+-  `Knoppix`_
+-  `BETT Show`_
+-  `StarOffice`_
 -  **ProgBox** (domain no longer around)
--  `BillReminder <http://billreminder.gnulinuxbrasil.org/>`__
--  `GeekDeck <http://geekdeck.wordpress.com/>`__
--  `Emblem Divide <http://emblemdivide.com/>`__
--  `Alchemy Reigns <http://alchemyreigns.wordpress.com/>`__
--  `Git in The Trenches (GITT) <https://github.com/cbx33/gitt>`__
--  `LaTeX <http://www.latex-project.org/>`__
--  `Dragon Ball <http://www.dragonball.com/>`__
--  `Bento lunchbox <http://www.bentolunchbox.com/>`__
--  `Tamagoyaki <https://secure.wikimedia.org/wikipedia/en/wiki/Tamagoyaki>`__
--  `Manga <https://secure.wikimedia.org/wikipedia/en/wiki/Manga>`__
--  `Hiragana <https://secure.wikimedia.org/wikipedia/en/wiki/Hiragana>`__ and `Katakana <https://secure.wikimedia.org/wikipedia/en/wiki/Katakana>`__
--  `Ethestra <https://github.com/cbx33/ethestra>`__
+-  `BillReminder`_
+-  `GeekDeck`_
+-  `Emblem Divide`_
+-  `Alchemy Reigns`_
+-  `Git in The Trenches (GITT)`_
+-  `LaTeX`_
+-  `Dragon Ball`_
+-  `Bento lunchbox`_
+-  `Tamagoyaki`_
+-  `Manga`_
+-  `Hiragana`_ and `Katakana`_
+-  `Ethestra`_
+
+
+.. _here: http://www.castalio.info/transcript-episode-17-pete-savage-git-in-the-trenches-gitt/
+.. _link: http://translate.google.com/translate?sl=auto&tl=pt&js=n&prev=_t&hl=en&ie=UTF-8&layout=2&eotf=1&u=http%3A%2F%2Fwww.castalio.info%2Ftranscript-episode-17-pete-savage-git-in-the-trenches-gitt%2F&act=url
+.. _Google Translate: http://translate.google.com/
+.. _Lagwagon: http://www.last.fm/music/Lagwagon
+.. _Green Day: http://www.last.fm/music/Green+Day
+.. _Mike Oldfield: http://www.last.fm/music/Mike+Oldfield
+.. _J-Rock: http://duckduckgo.com/?q=!lastfm%20Top%2010%20J-Rock%20Songs
+.. _J-Pop: http://www.last.fm/tag/j-pop
+.. _Night Watch: http://www.amazon.com/s/ref=ntt_athr_dp_sr_1?_encoding=UTF8&sort=relevancerank&search-alias=books&field-author=Sergei%20Lukyanenko#/ref=nb_sb_ss_i_1_11?field-keywords=night+watch+sergei+lukyanenko&url=search-alias%3Dstripbooks&sprefix=night+watch&rh=n%3A283155%2Ck%3Anight+watch+sergei+lukyanenko
+.. _Slashdot: http://slashdot.org/
+.. _Sergei Lukyanenko: https://secure.wikimedia.org/wikipedia/en/wiki/Sergei_Lukyanenko
+.. _The Register: http://www.theregister.co.uk/
+.. _The Daily WTF: http://thedailywtf.com/
+.. _Kamikaze Girls: http://www.imdb.com/title/tt0416220/
+.. _Inception: http://www.imdb.com/title/tt1375666/
+.. _The Prestige: http://www.imdb.com/title/tt0482571/
+.. _Greater New Hampshire Linux User Group (NHLUG): http://gnhlug.org/
+.. _"Building GUI applications with Python, Gtk and Glade": http://video.google.com/videoplay?docid=5838951374743244232
+.. _PyGtk: http://www.pygtk.org/
+.. _Duck Duck Go: https://duckduckgo.com/?t=i
+.. _Official Ubuntu Book: https://www.amazon.com/Official-Ubuntu-Book-Benjamin-Mako/dp/0132435942?tag=duckduckgo-d-20
+.. _Edubuntu: http://www.edubuntu.org/
+.. _PHP: http://www.php.net/
+.. _Knoppix: http://www.knoppix.org/
+.. _BETT Show: https://secure.wikimedia.org/wikipedia/en/wiki/BETT
+.. _StarOffice: https://secure.wikimedia.org/wikipedia/en/wiki/StarOffice
+.. _BillReminder: http://billreminder.gnulinuxbrasil.org/
+.. _GeekDeck: http://geekdeck.wordpress.com/
+.. _Emblem Divide: http://emblemdivide.com/
+.. _Alchemy Reigns: http://alchemyreigns.wordpress.com/
+.. _Git in The Trenches (GITT): https://github.com/cbx33/gitt
+.. _LaTeX: http://www.latex-project.org/
+.. _Dragon Ball: http://www.dragonball.com/
+.. _Bento lunchbox: http://www.bentolunchbox.com/
+.. _Tamagoyaki: https://secure.wikimedia.org/wikipedia/en/wiki/Tamagoyaki
+.. _Manga: https://secure.wikimedia.org/wikipedia/en/wiki/Manga
+.. _Hiragana: https://secure.wikimedia.org/wikipedia/en/wiki/Hiragana
+.. _Katakana: https://secure.wikimedia.org/wikipedia/en/wiki/Katakana
+.. _Ethestra: https://github.com/cbx33/ethestra

--- a/content/episodes/018-augusto-campos-br-linux-br-mac-efetividade.rst
+++ b/content/episodes/018-augusto-campos-br-linux-br-mac-efetividade.rst
@@ -11,19 +11,18 @@ Augusto Campos: BR-Linux, BR-Mac, Efetividade
 
    Augusto Campos: BR-Linux, BR-Mac, Efetividades
 
-Em um dia de muita chuva em Florianópolis, SC finalmente consegui bater
-um bom papo com o **Augusto Campos**, fundador dos super populares sites
-**BR-Linux**, **BR-Mac** e **Efetividade**! Devido à conexão que estava
-sofrendo muita perda de pacotes (**para cada 7 minutos de áudio, passei
-60 minutos editando**), mantivemos nossa entrevista por apenas 34
-minutos, mas mesmo assim deu tempo para discutirmos sobre a criação dos
-web sites, as mudanças que aconteceram durante os anos, sobre a
-entrevista com `GTalk Show <http://hacktoon.com/?s=augusto+campos>`__ do
-**Karlisson**, o mercado de trabalho em Santa Catarina, suas ferramentas
-de trabalho, livros, filmes e música. Uma novidade que também tenho é a
-participação mais que especial do **Evandro Pastor**, que literalmente
-**casou, mudou e não me convidou**! :) Mas ele já está bem melhor e quem
-sabe não volta no próximo episódio?
+Em um dia de muita chuva em Florianópolis, SC finalmente consegui bater um bom
+papo com o **Augusto Campos**, fundador dos super populares sites **BR-Linux**,
+**BR-Mac** e **Efetividade**! Devido à conexão que estava sofrendo muita perda
+de pacotes (**para cada 7 minutos de áudio, passei 60 minutos editando**), 
+mantivemos nossa entrevista por apenas 34 minutos, mas mesmo assim deu tempo
+para discutirmos sobre a criação dos web sites, as mudanças que aconteceram
+durante os anos, sobre a entrevista com `GTalk Show`_ do **Karlisson**,
+o mercado de trabalho em Santa Catarina, suas ferramentas de trabalho, livros,
+filmes e música. Uma novidade que também tenho é a participação mais que
+especial do **Evandro Pastor**, que literalmente **casou, mudou e não me
+convidou**! :) Mas ele já está bem melhor e quem sabe não volta no próximo
+episódio?
 
 Escute Agora
 ------------
@@ -58,39 +57,77 @@ Resumo
 
 Top 5
 -----
--  **Música**:  `Punk Rock <http://www.last.fm/search?q=punk+rock&from=ac>`__
--  **Música**:  `The Clash <http://www.last.fm/music/The+Clash>`__
--  **Música**:  `Ramones <http://www.last.fm/music/Ramones>`__
+-  **Música**:  `Punk Rock`_
+-  **Música**:  `The Clash`_
+-  **Música**:  `Ramones`_
 -  **Música**:  Top 50 dos anos 90
--  **Livro**:  `Life <http://www.amazon.com/Life-Keith-Richards/dp/031603441X/ref=sr_1_1?s=books&ie=UTF8&qid=1317570186&sr=1-1>`__ por `Keith Richards <https://pt.wikipedia.org/wiki/Keith_Richards>`__ e James Fox
--  **Livro**:  `Lobão 50 Anos a Mil <http://www.walmart.com.br/Produto/Livros/Literatura-Nacional/Nova-Fronteira/233090-Lobao-50-Anos-a-Mil>`__ por `Lobão <https://pt.wikipedia.org/wiki/Lob%C3%A3o_(m%C3%BAsico)>`__
--  **Filme**:  `Star Wars <http://www.imdb.com/title/tt0076759/>`__
--  **Filme**:  `Star Wars: The Empire Strikes Back <http://www.imdb.com/title/tt0080684/>`__
--  **Filme** :  `Star Wars: Return of the Jedi <http://www.imdb.com/title/tt0086190/>`__
--  **Filme**:  `Ferris Bueller's Day Off <http://www.imdb.com/title/tt0091042/>`__
--  **Filme**:  `Star Trek <http://www.imdb.com/find?s=all&q=star+trek>`__
+-  **Livro**:  `Life`_ por `Keith Richards`_ e James Fox
+-  **Livro**:  `Lobão 50 Anos a Mil`_ por `Lobão`_
+-  **Filme**:  `Star Wars`_
+-  **Filme**:  `Star Wars - The Empire Strikes Back`_
+-  **Filme** :  `Star Wars - Return of the Jedi`_
+-  **Filme**:  `Ferris Bueller's Day Off`_
+-  **Filme**:  `Star Trek`_
 
 Links
 -----
--  **Mora em**: `Florianópolis <http://maps.google.com/maps?f=q&source=s_q&hl=en&geocode=&q=Florianopolis+-+SC,+Brazil&aq=0&ie=UTF8&hq=&hnear=Florian%C3%B3polis+-+Santa+Catarina,+Brazil&t=h&z=11&vpsrc=0>`__,  \ **Santa Catarina**
--  `WordPress <http://wordpress.com>`__
--  `MySQL <http://www.mysql.com/>`__
--  `CentOS Linux <http://www.centos.org/>`__
--  `Istoé <http://www.istoe.com.br/>`__
--  `Marcelo Tosatti <https://pt.wikipedia.org/wiki/Marcelo_Tosatti>`__
--  `Red Hat Linux <https://duckduckgo.com/Red_Hat>`__
--  `GTalk Show <http://hacktoon.com/?s=augusto+campos>`__
--  `Estrella Roja <http://www.estrellaroja.info/>`__
--  `Mac OS <http://www.apple.com/macosx/>`__
--  `FlipBoard <http://flipboard.com/>`__
--  `BBEdit <http://www.barebones.com/products/bbedit/>`__
--  `Kate <https://pt.wikipedia.org/wiki/Kate_(KDE)>`__
--  `SSH <https://pt.wikipedia.org/wiki/Ssh>`__, `SCP <https://pt.wikipedia.org/wiki/Unix_SCP>`__
--  `AWK <https://pt.wikipedia.org/wiki/Awk>`__
--  `Pascal <https://pt.wikipedia.org/wiki/Pascal>`__
--  `Cobol <https://pt.wikipedia.org/wiki/Cobol>`__
--  `iPad <http://www.apple.com/ipad/>`__
--  `Kindle <https://pt.wikipedia.org/wiki/Kindle>`__
--  `eBook <https://pt.wikipedia.org/wiki/Ebook>`__
--  `Livraria Saraiva <http://www.livrariasaraiva.com.br/>`__
--  `Android <http://www.android.com/>`__
+-  **Mora em**: `Florianópolis`_,  \ **Santa Catarina**
+-  `WordPress`_
+-  `MySQL`_
+-  `CentOS Linux`_
+-  `Istoé`_
+-  `Marcelo Tosatti`_
+-  `Red Hat Linux`_
+-  `GTalk Show`_
+-  `Estrella Roja`_
+-  `Mac OS`_
+-  `FlipBoard`_
+-  `BBEdit`_
+-  `Kate`_
+-  `SSH`_, `SCP`_
+-  `AWK`_
+-  `Pascal`_
+-  `Cobol`_
+-  `iPad`_
+-  `Kindle`_
+-  `eBook`_
+-  `Livraria Saraiva`_
+-  `Android`_
+
+
+.. _GTalk Show: http://hacktoon.com/?s=augusto+campos
+.. _Punk Rock: http://www.last.fm/search?q=punk+rock&from=ac
+.. _The Clash: http://www.last.fm/music/The+Clash
+.. _Ramones: http://www.last.fm/music/Ramones
+.. _Life: http://www.amazon.com/Life-Keith-Richards/dp/031603441X/ref=sr_1_1?s=books&ie=UTF8&qid=1317570186&sr=1-1
+.. _Keith Richards: https://pt.wikipedia.org/wiki/Keith_Richards
+.. _Lobão 50 Anos a Mil: http://www.walmart.com.br/Produto/Livros/Literatura-Nacional/Nova-Fronteira/233090-Lobao-50-Anos-a-Mil
+.. _Lobão: https://pt.wikipedia.org/wiki/Lob%C3%A3o_(m%C3%BAsico)
+.. _Star Wars: http://www.imdb.com/title/tt0076759/
+.. _Star Wars - The Empire Strikes Back: http://www.imdb.com/title/tt0080684/
+.. _Star Wars - Return of the Jedi: http://www.imdb.com/title/tt0086190/
+.. _Ferris Bueller's Day Off: http://www.imdb.com/title/tt0091042/
+.. _Star Trek: http://www.imdb.com/find?s=all&q=star+trek
+.. _Florianópolis: http://maps.google.com/maps?f=q&source=s_q&hl=en&geocode=&q=Florianopolis+-+SC,+Brazil&aq=0&ie=UTF8&hq=&hnear=Florian%C3%B3polis+-+Santa+Catarina,+Brazil&t=h&z=11&vpsrc=0
+.. _WordPress: http://wordpress.com
+.. _MySQL: http://www.mysql.com/
+.. _CentOS Linux: http://www.centos.org/
+.. _Istoé: http://www.istoe.com.br/
+.. _Marcelo Tosatti: https://pt.wikipedia.org/wiki/Marcelo_Tosatti
+.. _Red Hat Linux: https://duckduckgo.com/Red_Hat
+.. _GTalk Show: http://hacktoon.com/?s=augusto+campos
+.. _Estrella Roja: http://www.estrellaroja.info/
+.. _Mac OS: http://www.apple.com/macosx/
+.. _FlipBoard: http://flipboard.com/
+.. _BBEdit: http://www.barebones.com/products/bbedit/
+.. _Kate: https://pt.wikipedia.org/wiki/Kate_(KDE)
+.. _SSH: https://pt.wikipedia.org/wiki/Ssh
+.. _SCP: https://pt.wikipedia.org/wiki/Unix_SCP
+.. _AWK: https://pt.wikipedia.org/wiki/Awk
+.. _Pascal: https://pt.wikipedia.org/wiki/Pascal
+.. _Cobol: https://pt.wikipedia.org/wiki/Cobol
+.. _iPad: http://www.apple.com/ipad/
+.. _Kindle: https://pt.wikipedia.org/wiki/Kindle
+.. _eBook: https://pt.wikipedia.org/wiki/Ebook
+.. _Livraria Saraiva: http://www.livrariasaraiva.com.br/
+.. _Android: http://www.android.com/

--- a/content/episodes/019-evandro-pastor-quarto-estudio.rst
+++ b/content/episodes/019-evandro-pastor-quarto-estudio.rst
@@ -14,9 +14,8 @@ Evandro Pastor: Quarto Estudio
 No episódio de hoje vocês vão ter a oportunidade de conhecer um pouco
 melhor o **Evandro Pastor**, co-fundador deste podcast e amigo de guerra
 de vários anos! Vocês vão aprender sobre como nasceu a sua companhia de
-web design, `Quarto Estudio <http://www.quartoestudio.com/web/>`__,
-sobre o tempo que ele passou trabalhando no `parque de diversões do
-Gugu <https://www.facebook.com/pages/Parque-do-Gugu/143888722341418>`__,
+web design, `Quarto Estudio`_,
+sobre o tempo que ele passou trabalhando no `parque de diversões do Gugu`_,
 o que ele pensa sobre os **cursos de web design no Brasil**, sua paixão
 por video games, sua mudança para o interiorrrr de São Paulo e o começo
 de seu Plano C.
@@ -63,38 +62,73 @@ Resumo
 
 Top 5
 -----
--  **Filmes**: `O Corvo <http://www.imdb.com/title/tt0109506/>`__
--  **Filmes**: `Blade Runner <http://www.imdb.com/title/tt0083658/>`__
--  **Filmes**: `Snatch <http://www.imdb.com/title/tt0208092/>`__
--  **Filmes**: `O Fabuloso Destino de Amelie Polan <http://www.imdb.com/title/tt0211915/>`__
--  **Filmes**: `Fogo Contra Fogo <http://www.imdb.com/title/tt0113277/>`__
--  **Música**: `The Prodigy <http://www.last.fm/search?q=The+Prodigy&from=ac>`__
--  **Música**: `Maria Rita <http://www.last.fm/music/Maria+Rita>`__
--  **Música**: `Oasis <http://www.last.fm/music/Oasis>`__
--  **Música**: `Iron Maden <http://www.last.fm/music/Iron+Maiden>`__
--  **Música**: `Genival Lacerda <http://www.last.fm/music/Genival%2520Lacerda?ac=genival%20lace>`__
--  **Música**: `Smiths <http://www.last.fm/music/The+Smiths>`__
--  **Música**: `Two Brothers on the Fourth Floor <http://www.last.fm/music/2+Brothers+On+The+4th+Floor>`__
+-  **Filmes**: `O Corvo`_
+-  **Filmes**: `Blade Runner`_
+-  **Filmes**: `Snatch`_
+-  **Filmes**: `O Fabuloso Destino de Amelie Polan`_
+-  **Filmes**: `Fogo Contra Fogo`_
+-  **Música**: `The Prodigy`_
+-  **Música**: `Maria Rita`_
+-  **Música**: `Oasis`_
+-  **Música**: `Iron Maden`_
+-  **Música**: `Genival Lacerda`_
+-  **Música**: `Smiths`_
+-  **Música**: `Two Brothers on the Fourth Floor`_
 -  **Música**: Too Limited (?)
--  **Livros/Web Sites**: `Portal R7 <http://www.r7.com/>`__
+-  **Livros/Web Sites**: `Portal R7`_
 
 Links
 -----
--  `Photoshop <https://www.photoshop.com/>`__
--  `Illustrator <http://www.adobe.com/products/illustrator.html>`__
--  `Dreamweaver <http://www.adobe.com/products/dreamweaver.html>`__
--  `Vídeo Tutorial de WordPress <http://quartoestudio.com/cursowordpress/>`__
--  `WordPress <http://wordpress.org/>`__
--  `Foresight Linux <http://www.foresightlinux.org/>`__
--  `Ana White <http://ana-white.com/>`__
--  `Gimp <http://www.gimp.org/>`__
--  `Inkscape <http://www.inkscape.org/>`__
--  `Conectiva Linux <https://en.wikipedia.org/wiki/Conectiva>`__
--  `TextWrangler <http://www.barebones.com/products/textwrangler/index.html>`__
--  `TextMate <http://www.macromates.com/>`__
--  `Safari <http://www.apple.com/safari/>`__
--  `Chrome <http://www.google.com/chrome/>`__
--  `Firefox <https://www.mozilla.org/en-US/firefox/new/>`__
--  `iTunes <http://www.apple.com/itunes/>`__
--  `Text Expander <http://smilesoftware.com/TextExpander/>`__
--  `Código Livre Cast <http://codigolivre.net/>`__
+-  `Photoshop`_
+-  `Illustrator`_
+-  `Dreamweaver`_
+-  `Vídeo Tutorial de WordPress`_
+-  `WordPress`_
+-  `Foresight Linux`_
+-  `Ana White`_
+-  `Gimp`_
+-  `Inkscape`_
+-  `Conectiva Linux`_
+-  `TextWrangler`_
+-  `TextMate`_
+-  `Safari`_
+-  `Chrome`_
+-  `Firefox`_
+-  `iTunes`_
+-  `Text Expander`_
+-  `Código Livre Cast`_
+
+
+.. _Quarto Estudio: http://www.quartoestudio.com/web/
+.. _parque de diversões do Gugu: https://www.facebook.com/pages/Parque-do-Gugu/143888722341418
+.. _O Corvo: http://www.imdb.com/title/tt0109506/
+.. _Código Livre Cast: http://codigolivre.net/
+.. _Blade Runner: http://www.imdb.com/title/tt0083658/
+.. _Snatch: http://www.imdb.com/title/tt0208092/
+.. _O Fabuloso Destino de Amelie Polan: http://www.imdb.com/title/tt0211915/
+.. _Fogo Contra Fogo: http://www.imdb.com/title/tt0113277/
+.. _The Prodigy: http://www.last.fm/search?q=The+Prodigy&from=ac
+.. _Maria Rita: http://www.last.fm/music/Maria+Rita
+.. _Oasis: http://www.last.fm/music/Oasis
+.. _Iron Maden: http://www.last.fm/music/Iron+Maiden
+.. _Genival Lacerda: http://www.last.fm/music/Genival%2520Lacerda?ac=genival%20lace
+.. _Smiths: http://www.last.fm/music/The+Smiths
+.. _Two Brothers on the Fourth Floor: http://www.last.fm/music/2+Brothers+On+The+4th+Floor
+.. _Portal R7: http://www.r7.com/
+.. _Photoshop: https://www.photoshop.com/
+.. _Illustrator: http://www.adobe.com/products/illustrator.html
+.. _Dreamweaver: http://www.adobe.com/products/dreamweaver.html
+.. _Vídeo Tutorial de WordPress: http://quartoestudio.com/cursowordpress/
+.. _WordPress: http://wordpress.org/
+.. _Foresight Linux: http://www.foresightlinux.org/
+.. _Ana White: http://ana-white.com/
+.. _Gimp: http://www.gimp.org/
+.. _Inkscape: http://www.inkscape.org/
+.. _Conectiva Linux: https://en.wikipedia.org/wiki/Conectiva
+.. _TextWrangler: http://www.barebones.com/products/textwrangler/index.html
+.. _TextMate: http://www.macromates.com/
+.. _Safari: http://www.apple.com/safari/
+.. _Chrome: http://www.google.com/chrome/
+.. _Firefox: https://www.mozilla.org/en-US/firefox/new/
+.. _iTunes: http://www.apple.com/itunes/
+.. _Text Expander: http://smilesoftware.com/TextExpander/

--- a/content/episodes/020-guilherme-salgado-canonical-e-linaro.rst
+++ b/content/episodes/020-guilherme-salgado-canonical-e-linaro.rst
@@ -53,62 +53,120 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Muse <http://www.last.fm/search?q=Muse>`__
--  **Música:** `Smashing Pumpkins <http://www.last.fm/search?q=Smashing+Pumpkins>`__
--  **Música:** `Fiona Apple <http://www.last.fm/search?q=Fiona+Apple>`__
--  **Música:** `Oasis <http://www.last.fm/search?q=Oasis>`__
--  **Música:** `Pearl Jam <http://www.last.fm/search?q=Pearl+Jam>`__
--  **Música:** `Nirvana <http://www.last.fm/search?q=Nirvana>`__
--  **Filmes:** `Donny Darco <http://www.imdb.com/find?s=all&q=Donny+Darco>`__
--  **Filmes:** `O Silêncio dos Inocentes <http://www.imdb.com/find?s=all&q=O+Silêncio+dos+Inocentes>`__
--  **Filmes:** `O Segredo dos Seus Olhos <http://www.imdb.com/find?s=all&q=O+Segredo+dos+Seus+Olhos>`__
--  **Filmes:** `Crash <http://www.imdb.com/find?s=all&q=Crash>`__
--  **Livros:** `The Dragons of Eden <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=The+Dragons+of+Eden>`__
--  **Livros:** `1984 <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=1984>`__
--  **Livros:** `Admirável Mundo Novo <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Admirável+Mundo+Novo>`__
--  **Livros:** `Os Miseráveis <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Os+Miseráveis>`__
+-  **Música:** `Muse`_
+-  **Música:** `Smashing Pumpkins`_
+-  **Música:** `Fiona Apple`_
+-  **Música:** `Oasis`_
+-  **Música:** `Pearl Jam`_
+-  **Música:** `Nirvana`_
+-  **Filmes:** `Donny Darco`_
+-  **Filmes:** `O Silêncio dos Inocentes`_
+-  **Filmes:** `O Segredo dos Seus Olhos`_
+-  **Filmes:** `Crash`_
+-  **Livros:** `The Dragons of Eden`_
+-  **Livros:** `1984`_
+-  **Livros:** `Admirável Mundo Novo`_
+-  **Livros:** `Os Miseráveis`_
 
 Links
 -----
--  `Linaro <https://duckduckgo.com/?q=Linaro>`__
--  `rootfs <https://duckduckgo.com/?q=rootfs>`__
--  `arm board <https://duckduckgo.com/?q=arm+board>`__
--  `kernel <https://duckduckgo.com/?q=kernel>`__
--  `toolchain <https://duckduckgo.com/?q=toolchain>`__
--  `git version control <https://duckduckgo.com/?q=git+version+control>`__
--  `Integração Contínua <https://duckduckgo.com/?q=Integração+Contínua>`__
--  `Hudson <https://duckduckgo.com/?q=Hudson>`__
--  `Jenkins <https://duckduckgo.com/?q=Jenkins>`__
--  `Lava Linaro Automation <https://duckduckgo.com/?q=Lava+Linaro+Automation>`__
--  `Canonical <https://duckduckgo.com/?q=Canonical>`__
--  `Ubuntu <https://duckduckgo.com/?q=Ubuntu>`__
--  `Async <https://duckduckgo.com/?q=Async>`__
--  `Launchpad <https://duckduckgo.com/?q=Launchpad>`__
--  `OpenID <https://duckduckgo.com/?q=OpenID>`__
--  `Christian Reis <https://duckduckgo.com/?q=Christian+Reis>`__
--  `Postgresql <https://duckduckgo.com/?q=Postgresql>`__
--  `Zope 3 <https://duckduckgo.com/?q=Zope+3>`__
--  `ZTK <https://duckduckgo.com/?q=ZTK>`__
--  `Storm <https://duckduckgo.com/?q=Storm>`__
--  `ORM <https://duckduckgo.com/?q=ORM>`__
--  `Guastavo Niemeier <https://duckduckgo.com/?q=Guastavo+Niemeier>`__
--  `Yui <https://duckduckgo.com/?q=Yui>`__
--  `Twisted <https://duckduckgo.com/?q=Twisted>`__
--  `Ubuntu Developer Summit <https://duckduckgo.com/?q=Ubuntu+Developer+Summit>`__
--  `Juju <https://duckduckgo.com/?q=Juju>`__
--  `Ensamble <https://duckduckgo.com/?q=Ensamble>`__
--  `apt-get <https://duckduckgo.com/?q=apt-get>`__
--  `Virtual Machine <https://duckduckgo.com/?q=Virtual+Machine>`__
--  `WordPress <https://duckduckgo.com/?q=WordPress>`__
--  `Amazon EC2 <https://duckduckgo.com/?q=Amazon+EC2>`__
--  `Load Balancer <https://duckduckgo.com/?q=Load+Balancer>`__
--  `HP <https://duckduckgo.com/?q=HP>`__
--  `Fedora Linux <https://duckduckgo.com/?q=Fedora+Linux>`__
--  `OpenSuse Linux <https://duckduckgo.com/?q=OpenSuse+Linux>`__
--  `Mint Linux <https://duckduckgo.com/?q=Mint+Linux>`__
--  `Red Hat Linux <https://duckduckgo.com/?q=Red+Hat+Linux>`__
--  `Snowboard <https://duckduckgo.com/?q=Snowboard>`__
--  `Dell <https://duckduckgo.com/?q=Dell>`__
--  `Carl Seagan <https://duckduckgo.com/?q=Carl+Seagan>`__
--  `George Orwell <https://duckduckgo.com/?q=George+Orwell>`__
--  `Carlitos Tevez <https://duckduckgo.com/?q=Carlitos+Tevez>`__
+-  `Linaro`_
+-  `rootfs`_
+-  `arm board`_
+-  `kernel`_
+-  `toolchain`_
+-  `git version control`_
+-  `Integração Contínua`_
+-  `Hudson`_
+-  `Jenkins`_
+-  `Lava Linaro Automation`_
+-  `Canonical`_
+-  `Ubuntu`_
+-  `Async`_
+-  `Launchpad`_
+-  `OpenID`_
+-  `Christian Reis`_
+-  `Postgresql`_
+-  `Zope 3`_
+-  `ZTK`_
+-  `Storm`_
+-  `ORM`_
+-  `Guastavo Niemeier`_
+-  `Yui`_
+-  `Twisted`_
+-  `Ubuntu Developer Summit`_
+-  `Juju`_
+-  `Ensamble`_
+-  `apt-get`_
+-  `Virtual Machine`_
+-  `WordPress`_
+-  `Amazon EC2`_
+-  `Load Balancer`_
+-  `HP`_
+-  `Fedora Linux`_
+-  `OpenSuse Linux`_
+-  `Mint Linux`_
+-  `Red Hat Linux`_
+-  `Snowboard`_
+-  `Dell`_
+-  `Carl Seagan`_
+-  `George Orwell`_
+-  `Carlitos Tevez`_
+
+
+.. _Muse: http://www.last.fm/search?q=Muse
+.. _Smashing Pumpkins: http://www.last.fm/search?q=Smashing+Pumpkins
+.. _Fiona Apple: http://www.last.fm/search?q=Fiona+Apple
+.. _Oasis: http://www.last.fm/search?q=Oasis
+.. _Pearl Jam: http://www.last.fm/search?q=Pearl+Jam
+.. _Nirvana: http://www.last.fm/search?q=Nirvana
+.. _Donny Darco: http://www.imdb.com/find?s=all&q=Donny+Darco
+.. _O Silêncio dos Inocentes: http://www.imdb.com/find?s=all&q=O+Silêncio+dos+Inocentes
+.. _O Segredo dos Seus Olhos: http://www.imdb.com/find?s=all&q=O+Segredo+dos+Seus+Olhos
+.. _Crash: http://www.imdb.com/find?s=all&q=Crash
+.. _The Dragons of Eden: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=The+Dragons+of+Eden
+.. _1984: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=1984
+.. _Admirável Mundo Novo: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Admirável+Mundo+Novo
+.. _Os Miseráveis: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Os+Miseráveis
+.. _Linaro: https://duckduckgo.com/?q=Linaro
+.. _rootfs: https://duckduckgo.com/?q=rootfs
+.. _arm board: https://duckduckgo.com/?q=arm+board
+.. _kernel: https://duckduckgo.com/?q=kernel
+.. _toolchain: https://duckduckgo.com/?q=toolchain
+.. _git version control: https://duckduckgo.com/?q=git+version+control
+.. _Integração Contínua: https://duckduckgo.com/?q=Integração+Contínua
+.. _Hudson: https://duckduckgo.com/?q=Hudson
+.. _Jenkins: https://duckduckgo.com/?q=Jenkins
+.. _Lava Linaro Automation: https://duckduckgo.com/?q=Lava+Linaro+Automation
+.. _Canonical: https://duckduckgo.com/?q=Canonical
+.. _Ubuntu: https://duckduckgo.com/?q=Ubuntu
+.. _Async: https://duckduckgo.com/?q=Async
+.. _Launchpad: https://duckduckgo.com/?q=Launchpad
+.. _OpenID: https://duckduckgo.com/?q=OpenID
+.. _Christian Reis: https://duckduckgo.com/?q=Christian+Reis
+.. _Postgresql: https://duckduckgo.com/?q=Postgresql
+.. _Zope 3: https://duckduckgo.com/?q=Zope+3
+.. _ZTK: https://duckduckgo.com/?q=ZTK
+.. _Storm: https://duckduckgo.com/?q=Storm
+.. _ORM: https://duckduckgo.com/?q=ORM
+.. _Guastavo Niemeier: https://duckduckgo.com/?q=Guastavo+Niemeier
+.. _Yui: https://duckduckgo.com/?q=Yui
+.. _Twisted: https://duckduckgo.com/?q=Twisted
+.. _Ubuntu Developer Summit: https://duckduckgo.com/?q=Ubuntu+Developer+Summit
+.. _Juju: https://duckduckgo.com/?q=Juju
+.. _Ensamble: https://duckduckgo.com/?q=Ensamble
+.. _apt-get: https://duckduckgo.com/?q=apt-get
+.. _Virtual Machine: https://duckduckgo.com/?q=Virtual+Machine
+.. _WordPress: https://duckduckgo.com/?q=WordPress
+.. _Amazon EC2: https://duckduckgo.com/?q=Amazon+EC2
+.. _Load Balancer: https://duckduckgo.com/?q=Load+Balancer
+.. _HP: https://duckduckgo.com/?q=HP
+.. _Fedora Linux: https://duckduckgo.com/?q=Fedora+Linux
+.. _OpenSuse Linux: https://duckduckgo.com/?q=OpenSuse+Linux
+.. _Mint Linux: https://duckduckgo.com/?q=Mint+Linux
+.. _Red Hat Linux: https://duckduckgo.com/?q=Red+Hat+Linux
+.. _Snowboard: https://duckduckgo.com/?q=Snowboard
+.. _Dell: https://duckduckgo.com/?q=Dell
+.. _Carl Seagan: https://duckduckgo.com/?q=Carl+Seagan
+.. _George Orwell: https://duckduckgo.com/?q=George+Orwell
+.. _Carlitos Tevez: https://duckduckgo.com/?q=Carlitos+Tevez

--- a/content/episodes/021-especial-andre-gondim-ubuntu-brasil.rst
+++ b/content/episodes/021-especial-andre-gondim-ubuntu-brasil.rst
@@ -11,22 +11,20 @@ Episódio Especial: André Gondim - Ubuntu Brasil
 
    André Gondim - Ubuntu Brasil
 
-Olá pessoal! Foi com um enorme pezar que eu recebi a
-`notícia <http://sejalivre.org/?p=5698>`__ sobre o falecimento de `André
-Gondim <http://andregondim.eti.br/>`__, uma figura do software livre
-Brasileiro que, infelizmente, nos deixou na semana passada... O meu
-relacionamento com o André começou em 2005 quando eu ainda administrava
-a equipe de traduções do **Ubuntu Brasil**. Assim como o **Fábio
-Nogueira** e **André Noel**, pessoas que eventualmente também ocuparam o
-cardo de coordenador desta equipe, o André Gondim foi uma das pessoas
-com quem eu tive o prazer de trabalhar e instruir no processo de
-traduções. Durante o nosso dia-a-dia, vi o trabalho e dedicação que ele
-sempre trazia e pude acompanhar o seu desenvolvimento e crescimento
-dentro da equipe. Mesmo depois que eu parei de contribuir com o Ubuntu e
-parti para traduções para o **GNOME**, **Xfce** e **LXDE**, com a ajuda
-do André foi possível sincronizar o trabalho entre as equipes e assim
-garantir que o Ubuntu tivesse uma tradução de qualidade e ao mesmo tempo
-respeitar o trabalho dos tradutores das equipes GNOME, etc, etc.
+Olá pessoal! Foi com um enorme pezar que eu recebi a `notícia`_ sobre
+o falecimento de `André Gondim`_, uma figura do software livre Brasileiro que,
+infelizmente, nos deixou na semana passada... O meu relacionamento com o André
+começou em 2005 quando eu ainda administrava a equipe de traduções do **Ubuntu
+Brasil**. Assim como o **Fábio Nogueira** e **André Noel**, pessoas que
+eventualmente também ocuparam o cardo de coordenador desta equipe, o André
+Gondim foi uma das pessoas com quem eu tive o prazer de trabalhar e instruir no
+processo de traduções. Durante o nosso dia-a-dia, vi o trabalho e dedicação que
+ele sempre trazia e pude acompanhar o seu desenvolvimento e crescimento dentro
+da equipe. Mesmo depois que eu parei de contribuir com o Ubuntu e parti para
+traduções para o **GNOME**, **Xfce** e **LXDE**, com a ajuda do André foi
+possível sincronizar o trabalho entre as equipes e assim garantir que o Ubuntu
+tivesse uma tradução de qualidade e ao mesmo tempo respeitar o trabalho dos
+tradutores das equipes GNOME, etc, etc.
 
 Escute Agora
 ------------
@@ -36,7 +34,7 @@ Escute Agora
 Contato
 -------
 -  **Blog**: http://andregondim.eti.br/
--  **Twitter**: https://twitter.com/#!/AndreGondim\ `  <http://andregondim.eti.br/>`__
+-  **Twitter**: https://twitter.com/#!/AndreGondim
 -  **Indenti.ca**:  http://identi.ca/andregondim
 -  **Facebook**:  https://www.facebook.com/andregondim?ref=ts
 
@@ -77,5 +75,10 @@ Fatos
 
 Link
 ----
-1. `Canonical observa um minuto de silêncio em memória ao trabalho e vida de André Gondim <http://twitpic.com/7av8qa>`__.
+1. `Canonical observa um minuto de silêncio em memória ao trabalho e vida de André Gondim`_.
 2. Entrevista pelo site Fridge do Ubuntu: http://fridge.ubuntu.com/2010/12/16/ubuntu-translations-interviews-andre-gondim-brazilian-portugese-translation-team/
+
+
+.. _notícia: http://sejalivre.org/?p=5698
+.. _André Gondim: http://andregondim.eti.br/
+.. _Canonical observa um minuto de silêncio em memória ao trabalho e vida de André Gondim: http://twitpic.com/7av8qa

--- a/content/episodes/022-alexandre-coster-asobo-studio.rst
+++ b/content/episodes/022-alexandre-coster-asobo-studio.rst
@@ -56,74 +56,145 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Jethro Tull <http://www.last.fm/search?q=Jethro+Tull>`__
--  **Música:** `Pink Floyd <http://www.last.fm/search?q=Pink+Floyd>`__
--  **Música:** `Queens of Stone Age <http://www.last.fm/search?q=Queens+of+Stone+Age>`__
--  **Música:** `Ween <http://www.last.fm/search?q=Ween>`__
--  **Música:** `Jupiter Maçã <http://www.last.fm/search?q=Jupiter+Maçã>`__
--  **Música:** `Paralamas <http://www.last.fm/search?q=Paralamas>`__
--  **Música:** `Engenheiros <http://www.last.fm/search?q=Engenheiros>`__
--  **Filmes:** `The Pacific <http://www.imdb.com/find?s=all&q=The+Pacific>`__
--  **Filmes:** `Monty Python <http://www.imdb.com/find?s=all&q=Monty+Python>`__
--  **Filmes:** `Snatch <http://www.imdb.com/find?s=all&q=Snatch>`__
--  **Filmes:** `Pulp Fiction <http://www.imdb.com/find?s=all&q=Pulp+Fiction>`__
--  **Filmes:** `Inglorious Bastards <http://www.imdb.com/find?s=all&q=Inglorious+Bastards>`__
--  **Filmes:** `Futurama <http://www.imdb.com/find?s=all&q=Futurama>`__
--  **Filmes:** `Life on Mars <http://www.imdb.com/find?s=all&q=Life+on+Mars>`__
--  **Jogos:** `Portal 2 <http://www.amazon.com/Portal-2-Xbox-360/dp/B002I0J9M0/ref=sr_1_1?s=videogames&ie=UTF8&qid=1320813372&sr=1-1>`__
--  **Jogos:** `Half Life 2 <http://www.amazon.com/Half-Life-2-Xbox/dp/B000B2YR74/ref=sr_1_2?s=videogames&ie=UTF8&qid=1320813403&sr=1-2>`__
--  **Jogos:** `Scribblenauts <http://www.amazon.com/Scribblenauts-Nintendo-DS/dp/B002B1TDV8/ref=sr_1_1?s=videogames&ie=UTF8&qid=1320813436&sr=1-1>`__
--  **Jogos:** `Just Cause 2 <http://www.amazon.com/Just-Cause-2-Xbox-360/dp/B0013RATNM/ref=sr_1_1?s=videogames&ie=UTF8&qid=1320813465&sr=1-1>`__
+-  **Música:** `Jethro Tull`_
+-  **Música:** `Pink Floyd`_
+-  **Música:** `Queens of Stone Age`_
+-  **Música:** `Ween`_
+-  **Música:** `Jupiter Maçã`_
+-  **Música:** `Paralamas`_
+-  **Música:** `Engenheiros`_
+-  **Filmes:** `The Pacific`_
+-  **Filmes:** `Monty Python`_
+-  **Filmes:** `Snatch`_
+-  **Filmes:** `Pulp Fiction`_
+-  **Filmes:** `Inglorious Bastards`_
+-  **Filmes:** `Futurama`_
+-  **Filmes:** `Life on Mars`_
+-  **Jogos:** `Portal 2`_
+-  **Jogos:** `Half Life 2`_
+-  **Jogos:** `Scribblenauts`_
+-  **Jogos:** `Just Cause 2`_
 
 Links
 -----
--  `Asobo Studio <https://duckduckgo.com/?q=Asobo+Studio>`__
--  `Western Union <https://duckduckgo.com/?q=Western+Union>`__
--  `Deer Hunter Tournament <https://duckduckgo.com/?q=Deer+Hunter+Tournament>`__
--  `Party Planner <https://duckduckgo.com/?q=Party+Planner>`__
--  `Wii <https://duckduckgo.com/?q=Wii>`__
--  `XBox <https://duckduckgo.com/?q=XBox>`__
--  `Nintendo DS <https://duckduckgo.com/?q=Nintendo+DS>`__
--  `Bordeaux <https://duckduckgo.com/?q=Bordeaux>`__
--  `TU Kaiserslautern <https://duckduckgo.com/?q=TU+Kaiserslautern>`__
--  `Boot Camp <https://duckduckgo.com/?q=Boot+Camp>`__
--  `Python <https://duckduckgo.com/?q=Python>`__
--  `Southlogic Studios <https://duckduckgo.com/?q=Southlogic+Studios>`__
--  `Matchmaking <https://duckduckgo.com/?q=Matchmaking>`__
--  `XBox Live <https://duckduckgo.com/?q=XBox+Live>`__
--  `Ubisoft <https://duckduckgo.com/?q=Ubisoft>`__
--  `C++ <https://duckduckgo.com/?q=C++>`__
--  `Facebook <https://duckduckgo.com/?q=Facebook>`__
--  `PHP <https://duckduckgo.com/?q=PHP>`__
--  `Elbit Systems Ltd. <https://duckduckgo.com/?q=Elbit+Systems+Ltd.>`__
--  `Unit Test <https://duckduckgo.com/?q=Unit+Test>`__
--  `Yonkpur <https://duckduckgo.com/?q=Yonkpur>`__
--  `GPS <https://duckduckgo.com/?q=GPS>`__
--  `Checkpoint <https://duckduckgo.com/?q=Checkpoint>`__
--  `Head Hunter <https://duckduckgo.com/?q=Head+Hunter>`__
--  `Asobo Studio Ratatuille <https://duckduckgo.com/?q=Asobo+Studio+Ratatuille>`__
--  `Pixar <https://duckduckgo.com/?q=Pixar>`__
--  `Toy Story 3 <https://duckduckgo.com/?q=Toy+Story+3>`__
--  `Asobo Studio Fuel <https://duckduckgo.com/?q=Asobo+Studio+Fuel>`__
--  `OpenGL <https://duckduckgo.com/?q=OpenGL>`__
--  `Pacman <https://duckduckgo.com/?q=Pacman>`__
--  `App Store <https://duckduckgo.com/?q=App+Store>`__
--  `Google Android <https://duckduckgo.com/?q=Google+Android>`__
--  `Humble Bundle <https://duckduckgo.com/?q=Humble+Bundle>`__
--  `EFF <https://duckduckgo.com/?q=EFF>`__
--  `Childs Play <https://duckduckgo.com/?q=Childs+Play>`__
--  `Companhia de jogos Aquiris <http://www.aquiris.com.br/pt/home/>`__
--  `PSN <https://duckduckgo.com/?q=PSN>`__
--  `Crayon Physics <https://duckduckgo.com/?q=Crayon+Physics>`__
--  `Atomic Zoombie Smasher <https://duckduckgo.com/?q=Atomic+Zoombie+Smasher>`__
--  `Tumbler <https://duckduckgo.com/?q=Tumbler>`__
--  `Foto de 2003 parecendo um indio <http://acoster.tumblr.com/post/10514260563/thats-me-as-a-freshman-at-ufrgs-back-in-2003>`__
--  `Unabomber <https://duckduckgo.com/?q=Unabomber>`__
--  `Eclipse <https://duckduckgo.com/?q=Eclipse>`__
--  `Visual Studio <https://duckduckgo.com/?q=Visual+Studio>`__
--  `Code Warrior <https://duckduckgo.com/?q=Code+Warrior>`__
--  `VIM <https://duckduckgo.com/?q=VIM>`__
--  `Emacs <https://duckduckgo.com/?q=Emacs>`__
--  `TextMate <https://duckduckgo.com/?q=TextMate>`__
--  `Valve <https://duckduckgo.com/?q=Valve>`__
--  `Steam <https://duckduckgo.com/?q=Steam>`__
+-  `Asobo Studio`_
+-  `Western Union`_
+-  `Deer Hunter Tournament`_
+-  `Party Planner`_
+-  `Wii`_
+-  `XBox`_
+-  `Nintendo DS`_
+-  `Bordeaux`_
+-  `TU Kaiserslautern`_
+-  `Boot Camp`_
+-  `Python`_
+-  `Southlogic Studios`_
+-  `Matchmaking`_
+-  `XBox Live`_
+-  `Ubisoft`_
+-  `C++`_
+-  `Facebook`_
+-  `PHP`_
+-  `Elbit Systems Ltd.`_
+-  `Unit Test`_
+-  `Yonkpur`_
+-  `GPS`_
+-  `Checkpoint`_
+-  `Head Hunter`_
+-  `Asobo Studio Ratatuille`_
+-  `Pixar`_
+-  `Toy Story 3`_
+-  `Asobo Studio Fuel`_
+-  `OpenGL`_
+-  `Pacman`_
+-  `App Store`_
+-  `Google Android`_
+-  `Humble Bundle`_
+-  `EFF`_
+-  `Childs Play`_
+-  `Companhia de jogos Aquiris`_
+-  `PSN`_
+-  `Crayon Physics`_
+-  `Atomic Zoombie Smasher`_
+-  `Tumbler`_
+-  `Foto de 2003 parecendo um indio`_
+-  `Unabomber`_
+-  `Eclipse`_
+-  `Visual Studio`_
+-  `Code Warrior`_
+-  `VIM`_
+-  `Emacs`_
+-  `TextMate`_
+-  `Valve`_
+-  `Steam`_
+
+
+
+.. _Jethro Tull: http://www.last.fm/search?q=Jethro+Tull
+.. _Pink Floyd: http://www.last.fm/search?q=Pink+Floyd
+.. _Queens of Stone Age: http://www.last.fm/search?q=Queens+of+Stone+Age
+.. _Ween: http://www.last.fm/search?q=Ween
+.. _Jupiter Maçã: http://www.last.fm/search?q=Jupiter+Maçã
+.. _Paralamas: http://www.last.fm/search?q=Paralamas
+.. _Engenheiros: http://www.last.fm/search?q=Engenheiros
+.. _The Pacific: http://www.imdb.com/find?s=all&q=The+Pacific
+.. _Monty Python: http://www.imdb.com/find?s=all&q=Monty+Python
+.. _Snatch: http://www.imdb.com/find?s=all&q=Snatch
+.. _Pulp Fiction: http://www.imdb.com/find?s=all&q=Pulp+Fiction
+.. _Inglorious Bastards: http://www.imdb.com/find?s=all&q=Inglorious+Bastards
+.. _Futurama: http://www.imdb.com/find?s=all&q=Futurama
+.. _Life on Mars: http://www.imdb.com/find?s=all&q=Life+on+Mars
+.. _Portal 2: http://www.amazon.com/Portal-2-Xbox-360/dp/B002I0J9M0/ref=sr_1_1?s=videogames&ie=UTF8&qid=1320813372&sr=1-1
+.. _Half Life 2: http://www.amazon.com/Half-Life-2-Xbox/dp/B000B2YR74/ref=sr_1_2?s=videogames&ie=UTF8&qid=1320813403&sr=1-2
+.. _Scribblenauts: http://www.amazon.com/Scribblenauts-Nintendo-DS/dp/B002B1TDV8/ref=sr_1_1?s=videogames&ie=UTF8&qid=1320813436&sr=1-1
+.. _Just Cause 2: http://www.amazon.com/Just-Cause-2-Xbox-360/dp/B0013RATNM/ref=sr_1_1?s=videogames&ie=UTF8&qid=1320813465&sr=1-1
+.. _Asobo Studio: https://duckduckgo.com/?q=Asobo+Studio
+.. _Western Union: https://duckduckgo.com/?q=Western+Union
+.. _Deer Hunter Tournament: https://duckduckgo.com/?q=Deer+Hunter+Tournament
+.. _Party Planner: https://duckduckgo.com/?q=Party+Planner
+.. _Wii: https://duckduckgo.com/?q=Wii
+.. _XBox: https://duckduckgo.com/?q=XBox
+.. _Nintendo DS: https://duckduckgo.com/?q=Nintendo+DS
+.. _Bordeaux: https://duckduckgo.com/?q=Bordeaux
+.. _TU Kaiserslautern: https://duckduckgo.com/?q=TU+Kaiserslautern
+.. _Boot Camp: https://duckduckgo.com/?q=Boot+Camp
+.. _Python: https://duckduckgo.com/?q=Python
+.. _Southlogic Studios: https://duckduckgo.com/?q=Southlogic+Studios
+.. _Matchmaking: https://duckduckgo.com/?q=Matchmaking
+.. _XBox Live: https://duckduckgo.com/?q=XBox+Live
+.. _Ubisoft: https://duckduckgo.com/?q=Ubisoft
+.. _C++: https://duckduckgo.com/?q=C++
+.. _Facebook: https://duckduckgo.com/?q=Facebook
+.. _PHP: https://duckduckgo.com/?q=PHP
+.. _Elbit Systems Ltd.: https://duckduckgo.com/?q=Elbit+Systems+Ltd.
+.. _Unit Test: https://duckduckgo.com/?q=Unit+Test
+.. _Yonkpur: https://duckduckgo.com/?q=Yonkpur
+.. _GPS: https://duckduckgo.com/?q=GPS
+.. _Checkpoint: https://duckduckgo.com/?q=Checkpoint
+.. _Head Hunter: https://duckduckgo.com/?q=Head+Hunter
+.. _Asobo Studio Ratatuille: https://duckduckgo.com/?q=Asobo+Studio+Ratatuille
+.. _Pixar: https://duckduckgo.com/?q=Pixar
+.. _Toy Story 3: https://duckduckgo.com/?q=Toy+Story+3
+.. _Asobo Studio Fuel: https://duckduckgo.com/?q=Asobo+Studio+Fuel
+.. _OpenGL: https://duckduckgo.com/?q=OpenGL
+.. _Pacman: https://duckduckgo.com/?q=Pacman
+.. _App Store: https://duckduckgo.com/?q=App+Store
+.. _Google Android: https://duckduckgo.com/?q=Google+Android
+.. _Humble Bundle: https://duckduckgo.com/?q=Humble+Bundle
+.. _EFF: https://duckduckgo.com/?q=EFF
+.. _Childs Play: https://duckduckgo.com/?q=Childs+Play
+.. _Companhia de jogos Aquiris: http://www.aquiris.com.br/pt/home/
+.. _PSN: https://duckduckgo.com/?q=PSN
+.. _Crayon Physics: https://duckduckgo.com/?q=Crayon+Physics
+.. _Atomic Zoombie Smasher: https://duckduckgo.com/?q=Atomic+Zoombie+Smasher
+.. _Tumbler: https://duckduckgo.com/?q=Tumbler
+.. _Foto de 2003 parecendo um indio: http://acoster.tumblr.com/post/10514260563/thats-me-as-a-freshman-at-ufrgs-back-in-2003
+.. _Unabomber: https://duckduckgo.com/?q=Unabomber
+.. _Eclipse: https://duckduckgo.com/?q=Eclipse
+.. _Visual Studio: https://duckduckgo.com/?q=Visual+Studio
+.. _Code Warrior: https://duckduckgo.com/?q=Code+Warrior
+.. _VIM: https://duckduckgo.com/?q=VIM
+.. _Emacs: https://duckduckgo.com/?q=Emacs
+.. _TextMate: https://duckduckgo.com/?q=TextMate
+.. _Valve: https://duckduckgo.com/?q=Valve
+.. _Steam: https://duckduckgo.com/?q=Steam

--- a/content/episodes/023-elvis-pfutzenreuter-conectiva-linux.rst
+++ b/content/episodes/023-elvis-pfutzenreuter-conectiva-linux.rst
@@ -52,43 +52,96 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Toccata und Fuge <http://www.last.fm/search?q=Toccata+und+Fuge>`__
--  **Música:** `Asia <http://www.last.fm/search?q=Asia>`__
--  **Música:** `Racionais Mc <http://www.last.fm/search?q=Racionais+Mc>`__
--  **Música:** `Facção Central <http://www.last.fm/search?q=Facção+Central>`__
--  **Música:** `Clara Nunes <http://www.last.fm/search?q=Clara+Nunes>`__
--  **Música:** `Jacob do Bandolim <http://www.last.fm/search?q=Jacob+do+Bandolim>`__
--  **Filmes:** `O Poderoso Chefão <http://www.imdb.com/find?s=all&q=O+Poderoso+Chefão>`__
--  **Filmes:** `Runaway Train <http://www.imdb.com/find?s=all&q=Runaway+Train>`__
--  **Filmes:** `Emperor of the North <http://www.imdb.com/find?s=all&q=Emperor+of+the+Noth>`__
--  **Livros:** `UNIX Network Programming: The sockets networking API <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=UNIX+Network+Programming:+The+sockets+networking+API>`__
--  **Livros:** `Inverted World <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Inverted+World>`__
--  **Livros:** `The smartest guys in the room <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=The+smartest+guys+in+the+room>`__
--  **Livros:** `No One Would Listen: A True Financial Thriller <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=No+One+Would+Listen:+A+True+Financial+Thriller>`__
--  **Livros:** `A ditadura derrotada <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=A+ditadura+derrotada>`__
+-  **Música:** `Toccata und Fuge`_
+-  **Música:** `Asia`_
+-  **Música:** `Racionais Mc`_
+-  **Música:** `Facção Central`_
+-  **Música:** `Clara Nunes`_
+-  **Música:** `Jacob do Bandolim`_
+-  **Filmes:** `O Poderoso Chefão`_
+-  **Filmes:** `Runaway Train`_
+-  **Filmes:** `Emperor of the North`_
+-  **Livros:** `UNIX Network Programming - The sockets networking API`_
+-  **Livros:** `Inverted World`_
+-  **Livros:** `The smartest guys in the room`_
+-  **Livros:** `No One Would Listen - A True Financial Thriller`_
+-  **Livros:** `A ditadura derrotada`_
 
 Links
 -----
--  `Conectiva Linux <https://duckduckgo.com/?q=Conectiva+Linux>`__
--  `Revista do Linux <https://duckduckgo.com/?q=Revista+do+Linux>`__
--  `Red Hat Linux <https://duckduckgo.com/?q=Red+Hat+Linux>`__
--  `ERP <https://duckduckgo.com/?q=ERP>`__
--  `Mandriva Linux <https://duckduckgo.com/?q=Mandriva+Linux>`__
--  `Mandrake Linux <https://duckduckgo.com/?q=Mandrake+Linux>`__
--  `Slackware Linux <https://duckduckgo.com/?q=Slackware+Linux>`__
--  `Debian Linux <https://duckduckgo.com/?q=Debian+Linux>`__
--  `Windows <https://duckduckgo.com/?q=Windows>`__
--  `Linux World Expo <https://duckduckgo.com/?q=Linux+World+Expo>`__
--  `Signove <http://www.signove.com/>`__
--  `Android <https://duckduckgo.com/?q=Android>`__
--  Aplicativo `1 <https://market.android.com/details?id=br.com.epx.andro12c&hl=pt_BR>`__, `2 <https://market.android.com/details?id=br.com.epx.andro12cd&hl=pt_BR>`__, `3 <https://market.android.com/details?id=br.com.epx.andro11c&hl=pt_BR>`__
--  `iOS <https://duckduckgo.com/?q=iOS>`__
--  Aplicativo `1 <http://itunes.apple.com/us/app/epx-12c/id463497845?mt=8>`__, `2 <http://itunes.apple.com/br/app/epx-11c/id463632731?mt=8>`__
--  `iPhone <https://duckduckgo.com/?q=iPhone>`__
--  `Biblioteca IEEE 11073 <http://oss.signove.com/index.php/Antidote:_IEEE_11073-20601_Library>`__
--  `Enron <https://duckduckgo.com/?q=Enron>`__
--  `Madoff <https://duckduckgo.com/?q=Madoff>`__
+-  `Conectiva Linux`_
+-  `Revista do Linux`_
+-  `Red Hat Linux`_
+-  `ERP`_
+-  `Mandriva Linux`_
+-  `Mandrake Linux`_
+-  `Slackware Linux`_
+-  `Debian Linux`_
+-  `Windows`_
+-  `Linux World Expo`_
+-  `Signove`_
+-  `Android`_
+    -  Aplicativo |android-app-1|, |android-app-2|, |android-app-3|
+
+-  `iOS`_
+    -  Aplicativo |ios-app-1|, |ios-app-2|
+
+-  `iPhone`_
+-  `Biblioteca IEEE 11073`_
+-  `Enron`_
+-  `Madoff`_
 
 .. class:: panel-body bg-info
 
-        **Música**: `Sunday Night Learning <http://soundcloud.com/clebertsuconic/sunday-night-lerning>`__ por `Clebert Suconic <http://soundcloud.com/clebertsuconic>`__.*
+        **Música**: `Sunday Night Learning`_ por `Clebert Suconic`_.*
+
+
+.. _Toccata und Fuge: http://www.last.fm/search?q=Toccata+und+Fuge
+.. _Asia: http://www.last.fm/search?q=Asia
+.. _Racionais Mc: http://www.last.fm/search?q=Racionais+Mc
+.. _Facção Central: http://www.last.fm/search?q=Facção+Central
+.. _Clara Nunes: http://www.last.fm/search?q=Clara+Nunes
+.. _Jacob do Bandolim: http://www.last.fm/search?q=Jacob+do+Bandolim
+.. _O Poderoso Chefão: http://www.imdb.com/find?s=all&q=O+Poderoso+Chefão
+.. _Runaway Train: http://www.imdb.com/find?s=all&q=Runaway+Train
+.. _Emperor of the North: http://www.imdb.com/find?s=all&q=Emperor+of+the+Noth
+.. _UNIX Network Programming - The sockets networking API: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=UNIX+Network+Programming:+The+sockets+networking+API
+.. _Inverted World: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Inverted+World
+.. _The smartest guys in the room: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=The+smartest+guys+in+the+room
+.. _No One Would Listen - A True Financial Thriller: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=No+One+Would+Listen:+A+True+Financial+Thriller
+.. _A ditadura derrotada: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=A+ditadura+derrotada
+.. _Conectiva Linux: https://duckduckgo.com/?q=Conectiva+Linux
+.. _Revista do Linux: https://duckduckgo.com/?q=Revista+do+Linux
+.. _Red Hat Linux: https://duckduckgo.com/?q=Red+Hat+Linux
+.. _ERP: https://duckduckgo.com/?q=ERP
+.. _Mandriva Linux: https://duckduckgo.com/?q=Mandriva+Linux
+.. _Mandrake Linux: https://duckduckgo.com/?q=Mandrake+Linux
+.. _Slackware Linux: https://duckduckgo.com/?q=Slackware+Linux
+.. _Debian Linux: https://duckduckgo.com/?q=Debian+Linux
+.. _Windows: https://duckduckgo.com/?q=Windows
+.. _Linux World Expo: https://duckduckgo.com/?q=Linux+World+Expo
+.. _Signove: http://www.signove.com/
+.. _Android: https://duckduckgo.com/?q=Android
+.. _iOS: https://duckduckgo.com/?q=iOS
+.. _iPhone: https://duckduckgo.com/?q=iPhone
+.. _Biblioteca IEEE 11073: http://oss.signove.com/index.php/Antidote:_IEEE_11073-20601_Library
+.. _Enron: https://duckduckgo.com/?q=Enron
+.. _Madoff: https://duckduckgo.com/?q=Madoff
+.. _Sunday Night Learning: http://soundcloud.com/clebertsuconic/sunday-night-lerning
+.. _Clebert Suconic: http://soundcloud.com/clebertsuconic
+
+.. |android-app-1| replace:: 1
+.. |android-app-2| replace:: 2
+.. |android-app-3| replace:: 3
+
+.. |ios-app-1| replace:: 1
+.. |ios-app-2| replace:: 2
+
+.. _android-app-1: https://market.android.com/details?id=br.com.epx.andro12c&hl=pt_BR
+.. _android-app-2: https://market.android.com/details?id=br.com.epx.andro12cd&hl=pt_BR
+.. _android-app-3: https://market.android.com/details?id=br.com.epx.andro11c&hl=pt_BR
+
+.. _ios-app-1: http://itunes.apple.com/us/app/epx-12c/id463497845?mt=8
+.. _ios-app-2: http://itunes.apple.com/br/app/epx-11c/id463632731?mt=8
+
+

--- a/content/episodes/024-ruda-moura-conectiva-linux.rst
+++ b/content/episodes/024-ruda-moura-conectiva-linux.rst
@@ -29,9 +29,9 @@ Escute Agora
 
 Contato
 -------
--  **Twitter**: `@\_\_ruda\_\_ <https://twitter.com/#!/__ruda__>`__
--  **Facebook**: `ruda.moura <https://www.facebook.com/ruda.moura>`__
--  **Site**: `rudamoura.com <http://rudamoura.com/>`__
+-  **Twitter**: `@__ruda__`_
+-  **Facebook**: `ruda.moura`_
+-  **Site**: `rudamoura.com`_
 
 Resumo
 ------
@@ -53,42 +53,81 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Yo La Tengo <http://www.last.fm/search?q=Yo+La+Tengo>`__
--  **Música:** `Mutantes <http://www.last.fm/search?q=Mutantes>`__
--  **Música:** `New Order <http://www.last.fm/search?q=New+Order>`__
--  **Música:** `Kraftwerk <http://www.last.fm/search?q=Kraftwerk>`__
--  **Filmes:** `Blade Runner <http://www.imdb.com/find?s=all&q=Blade+Runner>`__
--  **Filmes:** `Matrix <http://www.imdb.com/find?s=all&q=matrix>`__
--  **Filmes:** `Sociedade dos poetas mortos <http://www.imdb.com/find?s=all&q=Sociedade+dos+poetas+mortos>`__
--  **Filmes:** `7 anos no tibet <http://www.imdb.com/find?s=all&q=7+anos+no+tibet>`__
--  **Livros:** `Ruído Branco (DeLillo) <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Ruído+Branco+(DeLillo)>`__
--  **Livros:** `Qualquer um do Saramago <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Saramago>`__
--  **Livros:** `Art Of Computer Program (Knuth) <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Art+Of+Computer+Program+(Knuth)>`__
--  **Livros:** `Cammel Book (Larry Wall) <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Cammel+Book+(Larry+Wall)>`__
+-  **Música:** `Yo La Tengo`_
+-  **Música:** `Mutantes`_
+-  **Música:** `New Order`_
+-  **Música:** `Kraftwerk`_
+-  **Filmes:** `Blade Runner`_
+-  **Filmes:** `Matrix`_
+-  **Filmes:** `Sociedade dos poetas mortos`_
+-  **Filmes:** `7 anos no tibet`_
+-  **Livros:** `Ruído Branco (DeLillo)`_
+-  **Livros:** `Qualquer um do Saramago`_
+-  **Livros:** `Art Of Computer Program (Knuth)`_
+-  **Livros:** `Cammel Book (Larry Wall)`_
 
 Links
 -----
--  `Conectiva Linux <https://duckduckgo.com/?q=Conectiva+Linux>`__
--  `Slackware Linux <https://duckduckgo.com/?q=Slackware+Linux>`__
--  `Canonical <https://duckduckgo.com/?q=Canonical>`__
--  `Red Hat Linux <https://duckduckgo.com/?q=Red+Hat+Linux>`__
--  `Ubuntu Linux <https://duckduckgo.com/?q=Ubuntu+Linux>`__
--  `Fedora Linux <https://duckduckgo.com/?q=Fedora+Linux>`__
--  `GCC <https://duckduckgo.com/?q=GCC>`__
--  `Revista Linux <https://duckduckgo.com/?q=Revista+Linux>`__
--  `X.org <https://duckduckgo.com/?q=X.org>`__
--  `WinModem <https://duckduckgo.com/?q=WinModem>`__
--  `Novel <https://duckduckgo.com/?q=Novel>`__
--  `openSuse Linux <https://duckduckgo.com/?q=openSuse+Linux>`__
--  `Debian Linux <https://duckduckgo.com/?q=Debian+Linux>`__
--  `GNOME <https://duckduckgo.com/?q=GNOME>`__
--  `KDE <https://duckduckgo.com/?q=KDE>`__
--  `Qt <https://duckduckgo.com/?q=Qt>`__
--  `Avahi <https://duckduckgo.com/?q=Avahi>`__
--  `Tequila Baby <https://duckduckgo.com/?q=Tequila+Baby>`__
--  `Haxent <https://duckduckgo.com/?q=Haxent>`__
--  `Portal Terra <https://duckduckgo.com/?q=Portal+Terra>`__
+-  `Conectiva Linux`_
+-  `Slackware Linux`_
+-  `Canonical`_
+-  `Red Hat Linux`_
+-  `Ubuntu Linux`_
+-  `Fedora Linux`_
+-  `GCC`_
+-  `Revista Linux`_
+-  `X.org`_
+-  `WinModem`_
+-  `Novel`_
+-  `openSuse Linux`_
+-  `Debian Linux`_
+-  `GNOME`_
+-  `KDE`_
+-  `Qt`_
+-  `Avahi`_
+-  `Tequila Baby`_
+-  `Haxent`_
+-  `Portal Terra`_
 
 .. class:: panel-body bg-info
 
-        **Música**: `Sunday Night Learning <http://soundcloud.com/clebertsuconic/sunday-night-lerning>`__ por `Clebert Suconic <http://soundcloud.com/clebertsuconic>`__.*
+        **Música**: `Sunday Night Learning`_ por `Clebert Suconic`_.*
+
+
+.. _@__ruda__: https://twitter.com/#!/__ruda__
+.. _ruda.moura: https://www.facebook.com/ruda.moura
+.. _rudamoura.com: http://rudamoura.com/
+.. _Yo La Tengo: http://www.last.fm/search?q=Yo+La+Tengo
+.. _Mutantes: http://www.last.fm/search?q=Mutantes
+.. _New Order: http://www.last.fm/search?q=New+Order
+.. _Kraftwerk: http://www.last.fm/search?q=Kraftwerk
+.. _Blade Runner: http://www.imdb.com/find?s=all&q=Blade+Runner
+.. _Matrix: http://www.imdb.com/find?s=all&q=matrix
+.. _Sociedade dos poetas mortos: http://www.imdb.com/find?s=all&q=Sociedade+dos+poetas+mortos
+.. _7 anos no tibet: http://www.imdb.com/find?s=all&q=7+anos+no+tibet
+.. _Ruído Branco (DeLillo): http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Ruído+Branco+(DeLillo)
+.. _Qualquer um do Saramago: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Saramago
+.. _Art Of Computer Program (Knuth): http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Art+Of+Computer+Program+(Knuth)
+.. _Cammel Book (Larry Wall): http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Cammel+Book+(Larry+Wall)
+.. _Conectiva Linux: https://duckduckgo.com/?q=Conectiva+Linux
+.. _Slackware Linux: https://duckduckgo.com/?q=Slackware+Linux
+.. _Canonical: https://duckduckgo.com/?q=Canonical
+.. _Red Hat Linux: https://duckduckgo.com/?q=Red+Hat+Linux
+.. _Ubuntu Linux: https://duckduckgo.com/?q=Ubuntu+Linux
+.. _Fedora Linux: https://duckduckgo.com/?q=Fedora+Linux
+.. _GCC: https://duckduckgo.com/?q=GCC
+.. _Revista Linux: https://duckduckgo.com/?q=Revista+Linux
+.. _X.org: https://duckduckgo.com/?q=X.org
+.. _WinModem: https://duckduckgo.com/?q=WinModem
+.. _Novel: https://duckduckgo.com/?q=Novel
+.. _openSuse Linux: https://duckduckgo.com/?q=openSuse+Linux
+.. _Debian Linux: https://duckduckgo.com/?q=Debian+Linux
+.. _GNOME: https://duckduckgo.com/?q=GNOME
+.. _KDE: https://duckduckgo.com/?q=KDE
+.. _Qt: https://duckduckgo.com/?q=Qt
+.. _Avahi: https://duckduckgo.com/?q=Avahi
+.. _Tequila Baby: https://duckduckgo.com/?q=Tequila+Baby
+.. _Haxent: https://duckduckgo.com/?q=Haxent
+.. _Portal Terra: https://duckduckgo.com/?q=Portal+Terra
+.. _Sunday Night Learning: http://soundcloud.com/clebertsuconic/sunday-night-lerning
+.. _Clebert Suconic: http://soundcloud.com/clebertsuconic

--- a/content/episodes/025-joao-fernando-costa-junior-revista-espirito-livre.rst
+++ b/content/episodes/025-joao-fernando-costa-junior-revista-espirito-livre.rst
@@ -12,8 +12,7 @@ João Fernando Costa Júnior: Revista Espírito Livre
    João Fernando Costa Junior
 
 O entrevistado deste episódio é o **João Fernando Costa Júnior**,
-criador e mantenedor da `Revista Espírito
-Livre <http://www.revista.espiritolivre.org/>`__, "uma publicação em
+criador e mantenedor da `Revista Espírito Livre`_, "uma publicação em
 formato digital, a ser distribuída em PDF, gratuita e com foco em
 tecnologia, cultura livre, Internet, sempre tendo como plano de fundo o
 iniciativas como o software livre."
@@ -36,9 +35,9 @@ Escute Agora
 
 Contato
 -------
--  **Twitter**: `https://twitter.com/#!/jfcosta <https://twitter.com/#%21/jfcosta>`__
+-  **Twitter**: `@jfcosta`_
 -  **Facebook**: https://www.facebook.com/joao.fernando.costa
--  **Blog**: `Revista Espírito Livre <http://www.revista.espiritolivre.org/>`__
+-  **Blog**: `Revista Espírito Livre`_
 
 Resumo
 ------
@@ -58,45 +57,85 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Dream Theater <http://www.last.fm/search?q=Dream+Theater>`__
--  **Música:** `Angra <http://www.last.fm/search?q=Angra>`__
--  **Música:** `Enya <http://www.last.fm/search?q=Enya>`__
--  **Música:** `Kitaro <http://www.last.fm/search?q=kitaro>`__
--  **Música:** `Legião Urbana <http://www.last.fm/search?q=Legi%C3%A3o+Urbana>`__
--  **Música:** `Nightwish <http://www.last.fm/search?q=Nightwish>`__
--  **Música:** `Within Temptation <http://www.last.fm/search?q=Within+Temptation>`__
--  **Música:** `Stratovarious <http://www.last.fm/search?q=Stratovarious>`__
--  **Filmes:** `Trilogia O Senhor dos Anéis <http://www.imdb.com/find?s=all&q=Trilogia+O+Senhor+dos+An%C3%A9is>`__
--  **Filmes:** `Trilogia Matrix <http://www.imdb.com/find?s=all&q=Trilogia+Matrix>`__
--  **Filmes:** `V de Vingança <http://www.imdb.com/find?s=all&q=V+de+Vingan%C3%A7a>`__
--  **Filmes:** `Agentes do Destino <http://www.imdb.com/find?s=all&q=Agentes+do+Destino>`__
--  **Filmes:** `Super 8 <http://www.imdb.com/find?s=all&q=Super+8>`__
--  **Filmes:** `Source Code <http://www.imdb.com/find?s=all&q=Source+Code>`__
--  **Filmes:** `Apollo 18 <http://www.imdb.com/find?s=all&q=Apollo+18>`__
--  **Filmes:** `Dexter <http://www.imdb.com/find?s=all&q=Dexter>`__
--  **Filmes:** `Criminal Minds <http://www.imdb.com/find?s=all&q=Criminal+Minds>`__
--  **Filmes:** `The Mentalist <http://www.imdb.com/find?s=all&q=The+Mentalist>`__
--  **Livros:** `Bíblia <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=B%C3%ADblia>`__
--  **Livros:** `BR-Linux <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=BR-Linux>`__
--  **Livros:** `Folha <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Folha>`__
--  **Livros:** `Estadão <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Estad%C3%A3o>`__
+-  **Música:** `Dream Theater`_
+-  **Música:** `Angra`_
+-  **Música:** `Enya`_
+-  **Música:** `Kitaro`_
+-  **Música:** `Legião Urbana`_
+-  **Música:** `Nightwish`_
+-  **Música:** `Within Temptation`_
+-  **Música:** `Stratovarious`_
+-  **Filmes:** `Trilogia O Senhor dos Anéis`_
+-  **Filmes:** `Trilogia Matrix`_
+-  **Filmes:** `V de Vingança`_
+-  **Filmes:** `Agentes do Destino`_
+-  **Filmes:** `Super 8`_
+-  **Filmes:** `Source Code`_
+-  **Filmes:** `Apollo 18`_
+-  **Filmes:** `Dexter`_
+-  **Filmes:** `Criminal Minds`_
+-  **Filmes:** `The Mentalist`_
+-  **Livros:** `Bíblia`_
+-  **Livros:** `BR-Linux`_
+-  **Livros:** `Folha`_
+-  **Livros:** `Estadão`_
 
 Links
 -----
--  `Revista Espírito Livre <https://duckduckgo.com/?q=Revista+Esp%C3%ADrito+Livre>`__
--  `GTalk <https://duckduckgo.com/?q=GTalk>`__
--  `Jon Maddog Hall <https://duckduckgo.com/?q=Jon+Maddog+Hall>`__
--  `Xubuntu <https://duckduckgo.com/?q=Xubuntu>`__
--  `Xfce <https://duckduckgo.com/?q=Xfce>`__
--  `Scribus <https://duckduckgo.com/?q=Scribus>`__
--  `Inkscape <https://duckduckgo.com/?q=Inkscape>`__
--  `Gimp <https://duckduckgo.com/?q=Gimp>`__
--  `Google Docs <https://duckduckgo.com/?q=Google+Docs>`__
--  `LibreOffice <https://duckduckgo.com/?q=LibreOffice>`__
--  `GhostScript <https://duckduckgo.com/?q=GhostScript>`__
--  `PDF <https://duckduckgo.com/?q=PDF>`__
--  `Cloud Computing <https://duckduckgo.com/?q=Cloud+Computing>`__
+-  `Revista Espírito Livre (DuckDuckGo)`_
+-  `GTalk`_
+-  `Jon Maddog Hall`_
+-  `Xubuntu`_
+-  `Xfce`_
+-  `Scribus`_
+-  `Inkscape`_
+-  `Gimp`_
+-  `Google Docs`_
+-  `LibreOffice`_
+-  `GhostScript`_
+-  `PDF`_
+-  `Cloud Computing`_
 
 .. class:: panel-body bg-info
 
-        **Música**: `Sunday Night Learning <http://soundcloud.com/clebertsuconic/sunday-night-lerning>`__ por `Clebert Suconic <http://soundcloud.com/clebertsuconic>`__.*
+        **Música**: `Sunday Night Learning`_ por `Clebert Suconic`_.*
+
+.. _Revista Espírito Livre: http://www.revista.espiritolivre.org/
+.. _@jfcosta: https://twitter.com/jfcosta
+.. _Dream Theater: http://www.last.fm/search?q=Dream+Theater
+.. _Angra: http://www.last.fm/search?q=Angra
+.. _Enya: http://www.last.fm/search?q=Enya
+.. _Kitaro: http://www.last.fm/search?q=kitaro
+.. _Legião Urbana: http://www.last.fm/search?q=Legi%C3%A3o+Urbana
+.. _Nightwish: http://www.last.fm/search?q=Nightwish
+.. _Within Temptation: http://www.last.fm/search?q=Within+Temptation
+.. _Stratovarious: http://www.last.fm/search?q=Stratovarious
+.. _Trilogia O Senhor dos Anéis: http://www.imdb.com/find?s=all&q=Trilogia+O+Senhor+dos+An%C3%A9is
+.. _Trilogia Matrix: http://www.imdb.com/find?s=all&q=Trilogia+Matrix
+.. _V de Vingança: http://www.imdb.com/find?s=all&q=V+de+Vingan%C3%A7a
+.. _Agentes do Destino: http://www.imdb.com/find?s=all&q=Agentes+do+Destino
+.. _Super 8: http://www.imdb.com/find?s=all&q=Super+8
+.. _Source Code: http://www.imdb.com/find?s=all&q=Source+Code
+.. _Apollo 18: http://www.imdb.com/find?s=all&q=Apollo+18
+.. _Dexter: http://www.imdb.com/find?s=all&q=Dexter
+.. _Criminal Minds: http://www.imdb.com/find?s=all&q=Criminal+Minds
+.. _The Mentalist: http://www.imdb.com/find?s=all&q=The+Mentalist
+.. _Bíblia: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=B%C3%ADblia
+.. _BR-Linux: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=BR-Linux
+.. _Folha: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Folha
+.. _Estadão: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Estad%C3%A3o
+.. _Revista Espírito Livre (DuckDuckGo): https://duckduckgo.com/?q=Revista+Esp%C3%ADrito+Livre
+.. _GTalk: https://duckduckgo.com/?q=GTalk
+.. _Jon Maddog Hall: https://duckduckgo.com/?q=Jon+Maddog+Hall
+.. _Xubuntu: https://duckduckgo.com/?q=Xubuntu
+.. _Xfce: https://duckduckgo.com/?q=Xfce
+.. _Scribus: https://duckduckgo.com/?q=Scribus
+.. _Inkscape: https://duckduckgo.com/?q=Inkscape
+.. _Gimp: https://duckduckgo.com/?q=Gimp
+.. _Google Docs: https://duckduckgo.com/?q=Google+Docs
+.. _LibreOffice: https://duckduckgo.com/?q=LibreOffice
+.. _GhostScript: https://duckduckgo.com/?q=GhostScript
+.. _PDF: https://duckduckgo.com/?q=PDF
+.. _Cloud Computing: https://duckduckgo.com/?q=Cloud+Computing
+.. _Sunday Night Learning: http://soundcloud.com/clebertsuconic/sunday-night-lerning
+.. _Clebert Suconic: http://soundcloud.com/clebertsuconic

--- a/content/episodes/026-rodrigo-novo-conectiva-linux.rst
+++ b/content/episodes/026-rodrigo-novo-conectiva-linux.rst
@@ -48,51 +48,95 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Nina Simone <http://www.last.fm/search?q=Nina+Simone>`__
--  **Música:** `Frank Sinatra <http://www.last.fm/search?q=Frank+Sinatra>`__
--  **Filmes:** `The Shawshank Redemption <http://www.imdb.com/find?s=all&q=The+Shawshank+Redemption>`__
--  **Livros:** `Pot-Limit Omaha Poker <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Pot-Limit+Omaha+Poker>`__
--  **Livros:** `Advanced Pot-Limit Omaha: Small Ball and Short-Handed Play <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Advanced+Pot-Limit+OmahaÇ+Small+Ball+and+Short-Handed+Play>`__
+-  **Música:** `Nina Simone`_
+-  **Música:** `Frank Sinatra`_
+-  **Filmes:** `The Shawshank Redemption`_
+-  **Livros:** `Pot-Limit Omaha Poker`_
+-  **Livros:** `Advanced Pot-Limit Omaha\: Small Ball and Short-Handed Play`_
 
 Links
 -----
--  `Conectiva Linux <https://duckduckgo.com/?q=Conectiva+Linux>`__
--  `Canonical <https://duckduckgo.com/?q=Canonical>`__
--  `Ubuntu Developers Summit <https://duckduckgo.com/?q=Ubuntu+Developers+Summit>`__
--  `Mountain View <https://duckduckgo.com/?q=Mountain+View>`__
--  `Edubuntu <https://duckduckgo.com/?q=Edubuntu>`__
--  `GooglePlex <https://duckduckgo.com/?q=GooglePlex>`__
--  `Linux BR <https://duckduckgo.com/?q=Linux+BR>`__
--  `Arnaldo "pacman" <https://duckduckgo.com/?q=Arnaldo+>`__
--  `Parolin Linux <https://duckduckgo.com/?q=Parolin+Linux>`__
--  `MiniLinux <https://duckduckgo.com/?q=MiniLinux>`__
--  `DOS <https://duckduckgo.com/?q=DOS>`__
--  `GCC <https://duckduckgo.com/?q=GCC>`__
--  `Slackware Linux <https://duckduckgo.com/?q=Slackware+Linux>`__
--  `Red Hat Linux <https://duckduckgo.com/?q=Red+Hat+Linux>`__
--  `KDE <https://duckduckgo.com/?q=KDE>`__
--  `RPM <https://duckduckgo.com/?q=RPM>`__
--  `Midnight Commander <https://duckduckgo.com/?q=Midnight+Commander>`__
--  `Caldera Linux <https://duckduckgo.com/?q=Caldera+Linux>`__
--  `Caldera Graphical Installer <https://duckduckgo.com/?q=Caldera+Graphical+Installer>`__
--  `Qt <https://duckduckgo.com/?q=Qt>`__
--  `Anaconda Installer <https://duckduckgo.com/?q=Anaconda+Installer>`__
--  `CVS <https://duckduckgo.com/?q=CVS>`__
--  `NFS <https://duckduckgo.com/?q=NFS>`__
--  `TFTP <https://duckduckgo.com/?q=TFTP>`__
--  `Open Linux <https://duckduckgo.com/?q=Open+Linux>`__
--  `Silicon Valley <https://duckduckgo.com/?q=Silicon+Valley>`__
--  `Venture Capital <https://duckduckgo.com/?q=Venture+Capital>`__
--  `Mandrake Linux <https://duckduckgo.com/?q=Mandrake+Linux>`__
--  `Mandriva Linux <https://duckduckgo.com/?q=Mandriva+Linux>`__
--  `Universidade Federal de Santa Catarina <https://duckduckgo.com/?q=Universidade+Federal+de+Santa+Catarina>`__
--  `INDT <https://duckduckgo.com/?q=INDT>`__
--  `Livraria Saráiva <https://duckduckgo.com/?q=Livraria+Saráiva>`__
--  `IMDB.com <https://duckduckgo.com/?q=IMDB.com>`__
--  `Texas Holden Poker <https://duckduckgo.com/?q=Texas+Holden+Poker>`__
--  `Pot-Limit Omaha Poker <https://duckduckgo.com/?q=Pot-Limit+Omaha+Poker>`__
--  `Jeff Hwang <https://duckduckgo.com/?q=Jeff+Hwang>`__
+-  `Conectiva Linux`_
+-  `Canonical`_
+-  `Ubuntu Developers Summit`_
+-  `Mountain View`_
+-  `Edubuntu`_
+-  `GooglePlex`_
+-  `Linux BR`_
+-  `Arnaldo "pacman"`_
+-  `Parolin Linux`_
+-  `MiniLinux`_
+-  `DOS`_
+-  `GCC`_
+-  `Slackware Linux`_
+-  `Red Hat Linux`_
+-  `KDE`_
+-  `RPM`_
+-  `Midnight Commander`_
+-  `Caldera Linux`_
+-  `Caldera Graphical Installer`_
+-  `Qt`_
+-  `Anaconda Installer`_
+-  `CVS`_
+-  `NFS`_
+-  `TFTP`_
+-  `Open Linux`_
+-  `Silicon Valley`_
+-  `Venture Capital`_
+-  `Mandrake Linux`_
+-  `Mandriva Linux`_
+-  `Universidade Federal de Santa Catarina`_
+-  `INDT`_
+-  `Livraria Saráiva`_
+-  `IMDB.com`_
+-  `Texas Holden Poker`_
+-  `Pot-Limit Omaha Poker (DuckDuckGo)`_
+-  `Jeff Hwang`_
 
 .. class:: panel-body bg-info
 
-        **Música**: `Sunday Night Learning <http://soundcloud.com/clebertsuconic/sunday-night-lerning>`__ por `Clebert Suconic <http://soundcloud.com/clebertsuconic>`__.*
+        **Música**: `Sunday Night Learning`_ por `Clebert Suconic`_.*
+
+.. _Nina Simone: http://www.last.fm/search?q=Nina+Simone
+.. _Frank Sinatra: http://www.last.fm/search?q=Frank+Sinatra
+.. _The Shawshank Redemption: http://www.imdb.com/find?s=all&q=The+Shawshank+Redemption
+.. _Pot-Limit Omaha Poker: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Pot-Limit+Omaha+Poker
+.. _Advanced Pot-Limit Omaha\: Small Ball and Short-Handed Play: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Advanced+Pot-Limit+OmahaÇ+Small+Ball+and+Short-Handed+Play
+.. _Conectiva Linux: https://duckduckgo.com/?q=Conectiva+Linux
+.. _Canonical: https://duckduckgo.com/?q=Canonical
+.. _Ubuntu Developers Summit: https://duckduckgo.com/?q=Ubuntu+Developers+Summit
+.. _Mountain View: https://duckduckgo.com/?q=Mountain+View
+.. _Edubuntu: https://duckduckgo.com/?q=Edubuntu
+.. _GooglePlex: https://duckduckgo.com/?q=GooglePlex
+.. _Linux BR: https://duckduckgo.com/?q=Linux+BR
+.. _Arnaldo "pacman": https://duckduckgo.com/?q=Arnaldo+
+.. _Parolin Linux: https://duckduckgo.com/?q=Parolin+Linux
+.. _MiniLinux: https://duckduckgo.com/?q=MiniLinux
+.. _DOS: https://duckduckgo.com/?q=DOS
+.. _GCC: https://duckduckgo.com/?q=GCC
+.. _Slackware Linux: https://duckduckgo.com/?q=Slackware+Linux
+.. _Red Hat Linux: https://duckduckgo.com/?q=Red+Hat+Linux
+.. _KDE: https://duckduckgo.com/?q=KDE
+.. _RPM: https://duckduckgo.com/?q=RPM
+.. _Midnight Commander: https://duckduckgo.com/?q=Midnight+Commander
+.. _Caldera Linux: https://duckduckgo.com/?q=Caldera+Linux
+.. _Caldera Graphical Installer: https://duckduckgo.com/?q=Caldera+Graphical+Installer
+.. _Qt: https://duckduckgo.com/?q=Qt
+.. _Anaconda Installer: https://duckduckgo.com/?q=Anaconda+Installer
+.. _CVS: https://duckduckgo.com/?q=CVS
+.. _NFS: https://duckduckgo.com/?q=NFS
+.. _TFTP: https://duckduckgo.com/?q=TFTP
+.. _Open Linux: https://duckduckgo.com/?q=Open+Linux
+.. _Silicon Valley: https://duckduckgo.com/?q=Silicon+Valley
+.. _Venture Capital: https://duckduckgo.com/?q=Venture+Capital
+.. _Mandrake Linux: https://duckduckgo.com/?q=Mandrake+Linux
+.. _Mandriva Linux: https://duckduckgo.com/?q=Mandriva+Linux
+.. _Universidade Federal de Santa Catarina: https://duckduckgo.com/?q=Universidade+Federal+de+Santa+Catarina
+.. _INDT: https://duckduckgo.com/?q=INDT
+.. _Livraria Saráiva: https://duckduckgo.com/?q=Livraria+Saráiva
+.. _IMDB.com: https://duckduckgo.com/?q=IMDB.com
+.. _Texas Holden Poker: https://duckduckgo.com/?q=Texas+Holden+Poker
+.. _Pot-Limit Omaha Poker (DuckDuckGo): https://duckduckgo.com/?q=Pot-Limit+Omaha+Poker
+.. _Jeff Hwang: https://duckduckgo.com/?q=Jeff+Hwang
+.. _Sunday Night Learning: http://soundcloud.com/clebertsuconic/sunday-night-lerning
+.. _Clebert Suconic: http://soundcloud.com/clebertsuconic

--- a/content/episodes/027-rodrigo-padula-de-oliveira-ufrj.rst
+++ b/content/episodes/027-rodrigo-padula-de-oliveira-ufrj.rst
@@ -60,58 +60,109 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Beatles <http://www.last.fm/search?q=Beatles>`__
--  **Música:** `Raul Seixas <http://www.last.fm/search?q=Raul+Seixas>`__
--  **Música:** `AC/DC <http://www.last.fm/search?q=AC/DC>`__
--  **Música:** `IRA <http://www.last.fm/search?q=IRA>`__
--  **Música:** `Engenheiros do Hawai <http://www.last.fm/search?q=Engenheiros+do+Hawai>`__
--  **Música:** `Jack Johnson <http://www.last.fm/search?q=Jack+Johnson>`__
--  **Música:** `Iron Maiden <http://www.last.fm/search?q=Iron+Maiden>`__
--  **Filmes:** `O Exorcista <http://www.imdb.com/find?s=all&q=O+Exorcista>`__
--  **Filmes:** `Forrest Gump <http://www.imdb.com/find?s=all&q=Forrest+Gump>`__
--  **Filmes:** `A Profecia <http://www.imdb.com/find?s=all&q=A+Profecia>`__
--  **Filmes:** `O Senhor dos Anéis <http://www.imdb.com/find?s=all&q=O+Senhor+dos+Anéis>`__
--  **Filmes:** `2001 Uma Odisséia no Espaço <http://www.imdb.com/find?s=all&q=2001+Uma+Odisséia+no+Espaço>`__
--  **Livros:** `Starfish and the Spider <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Starfish+and+the+Spider>`__
--  **Livros:** `Utopia <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Utopia>`__
--  **Livros:** `A Arte da Guerra <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=A+Arte+da+Guerra>`__
--  **Livros:** `O Senhor dos Aneis <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=O+Senhor+dos+Aneis>`__
--  **Livros:** `Sistemas Operacionais Modernos <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Sistemas+Operacionais+Modernos>`__
--  **Livros:** `Aristóteles <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Aristóteles>`__
--  **Livros:** `Platão <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Platão>`__
+-  **Música:** `Beatles`_
+-  **Música:** `Raul Seixas`_
+-  **Música:** `AC/DC`_
+-  **Música:** `IRA`_
+-  **Música:** `Engenheiros do Hawai`_
+-  **Música:** `Jack Johnson`_
+-  **Música:** `Iron Maiden`_
+-  **Filmes:** `O Exorcista`_
+-  **Filmes:** `Forrest Gump`_
+-  **Filmes:** `A Profecia`_
+-  **Filmes:** `O Senhor dos Anéis`_
+-  **Filmes:** `2001 Uma Odisséia no Espaço`_
+-  **Livros:** `Starfish and the Spider`_
+-  **Livros:** `Utopia`_
+-  **Livros:** `A Arte da Guerra`_
+-  **Livros:** `O Senhor dos Aneis`_
+-  **Livros:** `Sistemas Operacionais Modernos`_
+-  **Livros:** `Aristóteles`_
+-  **Livros:** `Platão`_
 
 Links
 -----
--  `Linked.in <https://duckduckgo.com/?q=Linked.in>`__
--  `Linux Plus Magazine <https://duckduckgo.com/?q=Linux+Plus+Magazine>`__
--  `Conectiva Linux <https://duckduckgo.com/?q=Conectiva+Linux>`__
--  `Slackware Linux <https://duckduckgo.com/?q=Slackware+Linux>`__
--  `Red Hat Linux <https://duckduckgo.com/?q=Red+Hat+Linux>`__
--  `Fedora Linux <https://duckduckgo.com/?q=Fedora+Linux>`__
--  `Projeto Fedora <https://duckduckgo.com/?q=Projeto+Fedora>`__
--  `Hugo Cisneiro <https://duckduckgo.com/?q=Hugo+Cisneiro>`__
--  `Projeto KDE <https://duckduckgo.com/?q=Projeto+KDE>`__
--  `Projeto Mozilla <https://duckduckgo.com/?q=Projeto+Mozilla>`__
--  `UFRJ <https://duckduckgo.com/?q=UFRJ>`__
--  `Projeto GNOME <https://duckduckgo.com/?q=Projeto+GNOME>`__
--  `GNOME Shell <https://duckduckgo.com/?q=GNOME+Shell>`__
--  `Izabel Valverde <https://duckduckgo.com/?q=Izabel+Valverde>`__
--  `Jonh Wendell <https://duckduckgo.com/?q=Jonh+Wendell>`__
--  `Karen Sandler <https://duckduckgo.com/?q=Karen+Sandler>`__
--  `Compiz <https://duckduckgo.com/?q=Compiz>`__
--  `GNOME Board of Directors <https://duckduckgo.com/?q=GNOME+Board+of+Directors>`__
--  `Stormy Peters <https://duckduckgo.com/?q=Stormy+Peters>`__
--  `Canonical <https://duckduckgo.com/?q=Canonical>`__
--  `Formato ODF <https://duckduckgo.com/?q=Formato+ODF>`__
--  `Libre Office <https://duckduckgo.com/?q=Libre+Office>`__
--  `Navegador Internet Explorer <https://duckduckgo.com/?q=Navegador+Internet+Explorer>`__
--  `Navegador Firefox <https://duckduckgo.com/?q=Navegador+Firefox>`__
--  `Microsoft Windows <https://duckduckgo.com/?q=Microsoft+Windows>`__
--  `Microsoft Office <https://duckduckgo.com/?q=Microsoft+Office>`__
--  `Microsoft Academic Alliance <https://duckduckgo.com/?q=Microsoft+Academic+Alliance>`__
--  `Netscape <https://duckduckgo.com/?q=Netscape>`__
--  `Netflix <https://duckduckgo.com/?q=Netflix>`__
+-  `Linked.in`_
+-  `Linux Plus Magazine`_
+-  `Conectiva Linux`_
+-  `Slackware Linux`_
+-  `Red Hat Linux`_
+-  `Fedora Linux`_
+-  `Projeto Fedora`_
+-  `Hugo Cisneiro`_
+-  `Projeto KDE`_
+-  `Projeto Mozilla`_
+-  `UFRJ`_
+-  `Projeto GNOME`_
+-  `GNOME Shell`_
+-  `Izabel Valverde`_
+-  `Jonh Wendell`_
+-  `Karen Sandler`_
+-  `Compiz`_
+-  `GNOME Board of Directors`_
+-  `Stormy Peters`_
+-  `Canonical`_
+-  `Formato ODF`_
+-  `Libre Office`_
+-  `Navegador Internet Explorer`_
+-  `Navegador Firefox`_
+-  `Microsoft Windows`_
+-  `Microsoft Office`_
+-  `Microsoft Academic Alliance`_
+-  `Netscape`_
+-  `Netflix`_
 
 .. class:: panel-body bg-info
 
-        **Música**: `Sunday Night Learning <http://soundcloud.com/clebertsuconic/sunday-night-lerning>`__ por `Clebert Suconic <http://soundcloud.com/clebertsuconic>`__.*
+        **Música**: `Sunday Night Learning`_ por `Clebert Suconic`_.*
+
+.. _Beatles: http://www.last.fm/search?q=Beatles
+.. _Raul Seixas: http://www.last.fm/search?q=Raul+Seixas
+.. _AC/DC: http://www.last.fm/search?q=AC/DC
+.. _IRA: http://www.last.fm/search?q=IRA
+.. _Engenheiros do Hawai: http://www.last.fm/search?q=Engenheiros+do+Hawai
+.. _Jack Johnson: http://www.last.fm/search?q=Jack+Johnson
+.. _Iron Maiden: http://www.last.fm/search?q=Iron+Maiden
+.. _O Exorcista: http://www.imdb.com/find?s=all&q=O+Exorcista
+.. _Forrest Gump: http://www.imdb.com/find?s=all&q=Forrest+Gump
+.. _A Profecia: http://www.imdb.com/find?s=all&q=A+Profecia
+.. _O Senhor dos Anéis: http://www.imdb.com/find?s=all&q=O+Senhor+dos+Anéis
+.. _2001 Uma Odisséia no Espaço: http://www.imdb.com/find?s=all&q=2001+Uma+Odisséia+no+Espaço
+.. _Starfish and the Spider: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Starfish+and+the+Spider
+.. _Utopia: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Utopia
+.. _A Arte da Guerra: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=A+Arte+da+Guerra
+.. _O Senhor dos Aneis: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=O+Senhor+dos+Aneis
+.. _Sistemas Operacionais Modernos: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Sistemas+Operacionais+Modernos
+.. _Aristóteles: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Aristóteles
+.. _Platão: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Platão
+.. _Linked.in: https://duckduckgo.com/?q=Linked.in
+.. _Linux Plus Magazine: https://duckduckgo.com/?q=Linux+Plus+Magazine
+.. _Conectiva Linux: https://duckduckgo.com/?q=Conectiva+Linux
+.. _Slackware Linux: https://duckduckgo.com/?q=Slackware+Linux
+.. _Red Hat Linux: https://duckduckgo.com/?q=Red+Hat+Linux
+.. _Fedora Linux: https://duckduckgo.com/?q=Fedora+Linux
+.. _Projeto Fedora: https://duckduckgo.com/?q=Projeto+Fedora
+.. _Hugo Cisneiro: https://duckduckgo.com/?q=Hugo+Cisneiro
+.. _Projeto KDE: https://duckduckgo.com/?q=Projeto+KDE
+.. _Projeto Mozilla: https://duckduckgo.com/?q=Projeto+Mozilla
+.. _UFRJ: https://duckduckgo.com/?q=UFRJ
+.. _Projeto GNOME: https://duckduckgo.com/?q=Projeto+GNOME
+.. _GNOME Shell: https://duckduckgo.com/?q=GNOME+Shell
+.. _Izabel Valverde: https://duckduckgo.com/?q=Izabel+Valverde
+.. _Jonh Wendell: https://duckduckgo.com/?q=Jonh+Wendell
+.. _Karen Sandler: https://duckduckgo.com/?q=Karen+Sandler
+.. _Compiz: https://duckduckgo.com/?q=Compiz
+.. _GNOME Board of Directors: https://duckduckgo.com/?q=GNOME+Board+of+Directors
+.. _Stormy Peters: https://duckduckgo.com/?q=Stormy+Peters
+.. _Canonical: https://duckduckgo.com/?q=Canonical
+.. _Formato ODF: https://duckduckgo.com/?q=Formato+ODF
+.. _Libre Office: https://duckduckgo.com/?q=Libre+Office
+.. _Navegador Internet Explorer: https://duckduckgo.com/?q=Navegador+Internet+Explorer
+.. _Navegador Firefox: https://duckduckgo.com/?q=Navegador+Firefox
+.. _Microsoft Windows: https://duckduckgo.com/?q=Microsoft+Windows
+.. _Microsoft Office: https://duckduckgo.com/?q=Microsoft+Office
+.. _Microsoft Academic Alliance: https://duckduckgo.com/?q=Microsoft+Academic+Alliance
+.. _Netscape: https://duckduckgo.com/?q=Netscape
+.. _Netflix: https://duckduckgo.com/?q=Netflix
+.. _Sunday Night Learning: http://soundcloud.com/clebertsuconic/sunday-night-lerning
+.. _Clebert Suconic: http://soundcloud.com/clebertsuconic

--- a/content/episodes/028-marcelo-hashimoto-polly-twitter-client.rst
+++ b/content/episodes/028-marcelo-hashimoto-polly-twitter-client.rst
@@ -11,21 +11,18 @@ Marcelo Hashimoto: Polly Twitter Client
 
    Marcelo Hashimoto
 
-Olá pessoal! Sejam muito bem-vindos a mais um episódio, o segundo
-deste ano! O convidado de hoje é o **Marcelo Hashimoto**, desenvolvedor
-do cliente de **Twitter** chamado **Polly**! Se você curte programar com
-**Gtk** e **Python**, ou tem interesse em conhecer um aplicativo
-específico para o seu sistem **Linux** para acessar o Twitter, então dê
-uma olhadinho no programa do Marcelo. Ultimamente o Polly tem atraído
-bastante atenção, especialmente depois de ter saído em sites como o
-`OMG! Ubuntu <http://www.omgubuntu.co.uk/>`__, `Ubuntu
-Dicas <http://www.ubuntudicas.com.br/blog/>`__ e `Ubuntero
-Brasil <http://www.ubuntero.com.br/>`__!
-| Durante nosso bate-papo, o Marcelo conta porque decidiu criar "mais um
-cliente para o Twitter", o que faz ele destacar dos outros, a história
+Olá pessoal! Sejam muito bem-vindos a mais um episódio, o segundo deste ano!
+O convidado de hoje é o **Marcelo Hashimoto**, desenvolvedor do cliente de
+**Twitter** chamado **Polly**! Se você curte programar com **Gtk**
+e **Python**, ou tem interesse em conhecer um aplicativo específico para o seu
+sistem **Linux** para acessar o Twitter, então dê uma olhadinho no programa do
+Marcelo. Ultimamente o Polly tem atraído bastante atenção, especialmente depois
+de ter saído em sites como o `OMG! Ubuntu`_, `Ubuntu Dicas`_ e `Ubuntero
+Brasil`_!  | Durante nosso bate-papo, o Marcelo conta porque decidiu criar
+"mais um cliente para o Twitter", o que faz ele destacar dos outros, a história
 do nome do projeto (você sabia que o nome original do projeto era
-**schizobird**?), como lidar com usuários nos forums de pergunta, sobre
-seu doutorado, e o seu Top 5!
+**schizobird**?), como lidar com usuários nos forums de pergunta, sobre seu
+doutorado, e o seu Top 5!
 
 Escute Agora
 ------------
@@ -58,54 +55,104 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Halloween <http://www.last.fm/search?q=Halloween>`__
--  **Música:** `Savatage <http://www.last.fm/search?q=Savatage>`__
--  **Música:** `Metallica <http://www.last.fm/search?q=Metallica>`__
--  **Música:** `Megadeath <http://www.last.fm/search?q=Megadeath>`__
--  **Música:** `Annihilator <http://www.last.fm/search?q=Annihilator>`__
--  **Filmes:** `Piratas do Caribe <http://www.imdb.com/find?s=all&q=Piratas+do+Caribe>`__
--  **Livros:** `Victor Hugo <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Victor+Hugo>`__
--  **Livros:** `Os Miseráveis <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Os+Miseráveis>`__
--  **Livros:** `A Revolução dos Bichos <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=A+Revolução+dos+Bichos>`__
--  **Livros:** `O Parque dos Dinossáuros <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=O+Parque+dos+Dinossáuros>`__
--  **Livros:** `Augusto dos Anjos <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Augusto+dos+Anjos>`__
--  **Livros:** `Carlos Drummond de Andrade <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Carlos+Drummond+de+Andrade>`__
--  **Livros:** `William Blake <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=William+Blake>`__
--  **Livros:** `Baudelaire <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Baudelaire>`__
+-  **Música:** `Halloween`_
+-  **Música:** `Savatage`_
+-  **Música:** `Metallica`_
+-  **Música:** `Megadeath`_
+-  **Música:** `Annihilator`_
+-  **Filmes:** `Piratas do Caribe`_
+-  **Livros:** `Victor Hugo`_
+-  **Livros:** `Os Miseráveis`_
+-  **Livros:** `A Revolução dos Bichos`_
+-  **Livros:** `O Parque dos Dinossáuros`_
+-  **Livros:** `Augusto dos Anjos`_
+-  **Livros:** `Carlos Drummond de Andrade`_
+-  **Livros:** `William Blake`_
+-  **Livros:** `Baudelaire`_
 
 Links
 -----
--  `Polly Twitter Client <https://duckduckgo.com/?q=Polly+Twitter+Client>`__
--  `Twitter <https://duckduckgo.com/?q=Twitter>`__
--  `Ubuntu Linux <https://duckduckgo.com/?q=Ubuntu+Linux>`__
--  `Gwibber <https://duckduckgo.com/?q=Gwibber>`__
--  `Facebook <https://duckduckgo.com/?q=Facebook>`__
--  `Identi.ca <https://duckduckgo.com/?q=Identi.ca>`__
--  `Google Plus <https://duckduckgo.com/?q=Google+Plus>`__
--  `Pinot <https://duckduckgo.com/?q=Pinot>`__
--  `Hotot <https://duckduckgo.com/?q=Hotot>`__
--  `GNOME HIG <https://duckduckgo.com/?q=GNOME+HIG>`__
--  `Linguagem Python <https://duckduckgo.com/?q=Linguagem+Python>`__
--  `Gtk <https://duckduckgo.com/?q=Gtk>`__
--  `Foresight Linux <https://duckduckgo.com/?q=Foresight+Linux>`__
--  `Gtk3 <https://duckduckgo.com/?q=Gtk3>`__
--  `OMG Ubuntu <https://duckduckgo.com/?q=OMG+Ubuntu>`__
--  `Ubuntu Dicas <https://duckduckgo.com/?q=Ubuntu+Dicas>`__
--  `Ubuntero BR <https://duckduckgo.com/?q=Ubuntero+BR>`__
--  `BillReminder <https://duckduckgo.com/?q=BillReminder>`__
--  `Debian Linux <https://duckduckgo.com/?q=Debian+Linux>`__
--  `Monty Python <https://duckduckgo.com/?q=Monty+Python>`__
--  `Python Socks <https://duckduckgo.com/?q=Python+Socks>`__
--  `Launchpad <https://duckduckgo.com/?q=Launchpad>`__
--  `Penny Arcade <https://duckduckgo.com/?q=Penny+Arcade>`__
--  `Visão Computacional <https://duckduckgo.com/?q=Visão+Computacional>`__
--  `C++ <https://duckduckgo.com/?q=C++>`__
--  `OpenCV <https://duckduckgo.com/?q=OpenCV>`__
--  `libcv <https://duckduckgo.com/?q=libcv>`__
--  `Livraria Cultura <https://duckduckgo.com/?q=Livraria+Cultura>`__
--  `Enquete para o novo nome do aplicativo <http://www.omgubuntu.co.uk/2011/07/scizobird-seeking/>`__
--  `Monty Python: Polly o papagaio <http://www.myspace.com/video/vid/1390811>`__
+-  `Polly Twitter Client`_
+-  `Twitter`_
+-  `Ubuntu Linux`_
+-  `Gwibber`_
+-  `Facebook`_
+-  `Identi.ca`_
+-  `Google Plus`_
+-  `Pinot`_
+-  `Hotot`_
+-  `GNOME HIG`_
+-  `Linguagem Python`_
+-  `Gtk`_
+-  `Foresight Linux`_
+-  `Gtk3`_
+-  `OMG Ubuntu`_
+-  `Ubuntu Dicas (DuckDuckGo)`_
+-  `Ubuntero BR`_
+-  `BillReminder`_
+-  `Debian Linux`_
+-  `Monty Python`_
+-  `Python Socks`_
+-  `Launchpad`_
+-  `Penny Arcade`_
+-  `Visão Computacional`_
+-  `C++`_
+-  `OpenCV`_
+-  `libcv`_
+-  `Livraria Cultura`_
+-  `Enquete para o novo nome do aplicativo`_
+-  `Monty Python - Polly o papagaio`_
 
 .. class:: panel-body bg-info
 
-        **Música**: `Sunday Night Learning <http://soundcloud.com/clebertsuconic/sunday-night-lerning>`__ por `Clebert Suconic <http://soundcloud.com/clebertsuconic>`__.*
+        **Música**: `Sunday Night Learning`_ por `Clebert Suconic`_.*
+
+.. _OMG! Ubuntu: http://www.omgubuntu.co.uk/
+.. _Halloween: http://www.last.fm/search?q=Halloween
+.. _Savatage: http://www.last.fm/search?q=Savatage
+.. _Metallica: http://www.last.fm/search?q=Metallica
+.. _Megadeath: http://www.last.fm/search?q=Megadeath
+.. _Annihilator: http://www.last.fm/search?q=Annihilator
+.. _Piratas do Caribe: http://www.imdb.com/find?s=all&q=Piratas+do+Caribe
+.. _Victor Hugo: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Victor+Hugo
+.. _Os Miseráveis: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Os+Miseráveis
+.. _A Revolução dos Bichos: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=A+Revolução+dos+Bichos
+.. _O Parque dos Dinossáuros: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=O+Parque+dos+Dinossáuros
+.. _Augusto dos Anjos: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Augusto+dos+Anjos
+.. _Carlos Drummond de Andrade: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Carlos+Drummond+de+Andrade
+.. _William Blake: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=William+Blake
+.. _Baudelaire: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Baudelaire
+.. _Polly Twitter Client: https://duckduckgo.com/?q=Polly+Twitter+Client
+.. _Twitter: https://duckduckgo.com/?q=Twitter
+.. _Ubuntu Linux: https://duckduckgo.com/?q=Ubuntu+Linux
+.. _Gwibber: https://duckduckgo.com/?q=Gwibber
+.. _Facebook: https://duckduckgo.com/?q=Facebook
+.. _Identi.ca: https://duckduckgo.com/?q=Identi.ca
+.. _Google Plus: https://duckduckgo.com/?q=Google+Plus
+.. _Pinot: https://duckduckgo.com/?q=Pinot
+.. _Hotot: https://duckduckgo.com/?q=Hotot
+.. _GNOME HIG: https://duckduckgo.com/?q=GNOME+HIG
+.. _Linguagem Python: https://duckduckgo.com/?q=Linguagem+Python
+.. _Gtk: https://duckduckgo.com/?q=Gtk
+.. _Foresight Linux: https://duckduckgo.com/?q=Foresight+Linux
+.. _Gtk3: https://duckduckgo.com/?q=Gtk3
+.. _OMG Ubuntu: https://duckduckgo.com/?q=OMG+Ubuntu
+.. _Ubuntu Dicas (DuckDuckGo): https://duckduckgo.com/?q=Ubuntu+Dicas
+.. _Ubuntero BR: https://duckduckgo.com/?q=Ubuntero+BR
+.. _BillReminder: https://duckduckgo.com/?q=BillReminder
+.. _Debian Linux: https://duckduckgo.com/?q=Debian+Linux
+.. _Monty Python: https://duckduckgo.com/?q=Monty+Python
+.. _Python Socks: https://duckduckgo.com/?q=Python+Socks
+.. _Launchpad: https://duckduckgo.com/?q=Launchpad
+.. _Penny Arcade: https://duckduckgo.com/?q=Penny+Arcade
+.. _Visão Computacional: https://duckduckgo.com/?q=Visão+Computacional
+.. _C++: https://duckduckgo.com/?q=C++
+.. _OpenCV: https://duckduckgo.com/?q=OpenCV
+.. _libcv: https://duckduckgo.com/?q=libcv
+.. _Livraria Cultura: https://duckduckgo.com/?q=Livraria+Cultura
+.. _Enquete para o novo nome do aplicativo: http://www.omgubuntu.co.uk/2011/07/scizobird-seeking/
+.. _Monty Python - Polly o papagaio: http://www.myspace.com/video/vid/1390811
+.. _Sunday Night Learning: http://soundcloud.com/clebertsuconic/sunday-night-lerning
+.. _Clebert Suconic: http://soundcloud.com/clebertsuconic
+.. _Ubuntu Dicas: http://www.ubuntudicas.com.br/blog/
+.. _Ubuntero Brasil: http://www.ubuntero.com.br/

--- a/content/episodes/029-ana-cristina-fricke-matte-text-livre.rst
+++ b/content/episodes/029-ana-cristina-fricke-matte-text-livre.rst
@@ -14,8 +14,7 @@ Ana Cristina Fricke Matte: Texto Livre
 Olá pessoal! Sejam muito bem-vindos a mais um episódio, que quase não
 saiu devido a problemas técnicos de última hora! Mas felizmente consegui
 resgatar e editar um bate-papo muito interessante que tive com a **Ana
-Cristina Fricke Matte**, ou "a **acris**  do `Texto
-Livre <http://www.textolivre.org/site/>`__", como ele prefere. ;)
+Cristina Fricke Matte**, ou "a **acris**  do `Texto Livre`_", como ele prefere. ;)
 
 A acris conta sobre como a idéia do **Texto Livre** nasceu depois de uma
 reunião com a equipe do **Ubuntu Brasil** em 2006, os problemas que
@@ -55,53 +54,94 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Madonna <http://www.last.fm/search?q=Madonna>`__
--  **Filmes:** `Dexter <http://www.imdb.com/find?s=all&q=Dexter>`__
--  **Livros:** `Ponto de Impacto <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Ponto+de+Impacto>`__
+-  **Música:** `Madonna`_
+-  **Filmes:** `Dexter`_
+-  **Livros:** `Ponto de Impacto`_
 
 Links
 -----
--  `Polly Twitter Client <https://duckduckgo.com/?q=Polly+Twitter+Client>`__
--  `Texto Livre <https://duckduckgo.com/?q=Texto+Livre>`__
--  `Universidade Federal de Minas Gerais <https://duckduckgo.com/?q=Universidade+Federal+de+Minas+Gerais>`__
--  `Evidosol <https://duckduckgo.com/?q=Evidosol>`__
--  `Revista Texto Livre <https://duckduckgo.com/?q=Revista+Texto+Livre>`__
--  `Ubuntu Brasil <https://duckduckgo.com/?q=Ubuntu+Brasil>`__
--  `Xoops <https://duckduckgo.com/?q=Xoops>`__
--  `Ubuntu Linux <https://duckduckgo.com/?q=Ubuntu+Linux>`__
--  `Underlinux <https://duckduckgo.com/?q=Underlinux>`__
--  `Kernel <https://duckduckgo.com/?q=Kernel>`__
--  `Ning <https://duckduckgo.com/?q=Ning>`__
--  `Moodle <https://duckduckgo.com/?q=Moodle>`__
--  `Software Livre Educacional <https://duckduckgo.com/?q=Software+Livre+Educacional>`__
--  `Associação Software Livre <https://duckduckgo.com/?q=Associação+Software+Livre>`__
--  `Portal do Professor Livre na Rede <https://duckduckgo.com/?q=Portal+do+Professor+Livre+na+Rede>`__
--  `Inteligência Artificial <https://duckduckgo.com/?q=Inteligência+Artificial>`__
--  `Inteligência Adaptiva <https://duckduckgo.com/?q=Inteligência+Adaptiva>`__
--  `Universidade de São Paulo <https://duckduckgo.com/?q=Universidade+de+São+Paulo>`__
--  `Kurt Kraut <https://duckduckgo.com/?q=Kurt+Kraut>`__
--  `UFBA <https://duckduckgo.com/?q=UFBA>`__
--  `UNESP <https://duckduckgo.com/?q=UNESP>`__
--  `Laboratório de Semiótica e Tecnologia <https://duckduckgo.com/?q=Laboratório+de+Semiótica+e+Tecnologia>`__
--  `FAPEMIG <https://duckduckgo.com/?q=FAPEMIG>`__
--  `Amadeus <http://amadeus.cin.ufpe.br/blog/>`__
--  `WordPress <https://duckduckgo.com/?q=WordPress>`__
--  `ULGG <https://duckduckgo.com/?q=ULGG>`__
--  `GT de Educação do FILS <https://duckduckgo.com/?q=GT+de+Educação+do+FILS>`__
--  `FISL <https://duckduckgo.com/?q=FISL>`__
--  `Praat <https://duckduckgo.com/?q=Praat>`__
--  `Fedora Linux <https://duckduckgo.com/?q=Fedora+Linux>`__
--  `Slackware Linux <https://duckduckgo.com/?q=Slackware+Linux>`__
--  `Brasnet <https://duckduckgo.com/?q=Brasnet>`__
--  `Freenode <https://duckduckgo.com/?q=Freenode>`__
--  `UML <https://duckduckgo.com/?q=UML>`__
+-  `Polly Twitter Client`_
+-  `Texto Livre`_
+-  `Universidade Federal de Minas Gerais`_
+-  `Evidosol`_
+-  `Revista Texto Livre`_
+-  `Ubuntu Brasil`_
+-  `Xoops`_
+-  `Ubuntu Linux`_
+-  `Underlinux`_
+-  `Kernel`_
+-  `Ning`_
+-  `Moodle`_
+-  `Software Livre Educacional`_
+-  `Associação Software Livre`_
+-  `Portal do Professor Livre na Rede`_
+-  `Inteligência Artificial`_
+-  `Inteligência Adaptiva`_
+-  `Universidade de São Paulo`_
+-  `Kurt Kraut`_
+-  `UFBA`_
+-  `UNESP`_
+-  `Laboratório de Semiótica e Tecnologia`_
+-  `FAPEMIG`_
+-  `Amadeus`_
+-  `WordPress`_
+-  `ULGG`_
+-  `GT de Educação do FILS`_
+-  `FISL`_
+-  `Praat`_
+-  `Fedora Linux`_
+-  `Slackware Linux`_
+-  `Brasnet`_
+-  `Freenode`_
+-  `UML`_
 
-Para quem escutou o `último episódio <http://wp.me/p1mMfJ-20>`__ com o
+Para quem escutou o `último episódio`_ com o
 **Marcelo Hashimoto** sobre o cliente de **Twitter Polly**, e teve
 problemas por causa de incompatibilidade com versões do **Python <
 2.6**, ele já tem o código "portado", que pode ser encontrado
-aqui: \ https://code.launchpad.net/~conscioususer/polly/python2.6
+aqui: https://code.launchpad.net/~conscioususer/polly/python2.6
 
 .. class:: panel-body bg-info
 
-        **Música**: `Sunday Night Learning <http://soundcloud.com/clebertsuconic/sunday-night-lerning>`__ por `Clebert Suconic <http://soundcloud.com/clebertsuconic>`__.*
+        **Música**: `Sunday Night Learning`_ por `Clebert Suconic`_.*
+
+.. _Texto Livre: http://www.textolivre.org/site/
+.. _Madonna: http://www.last.fm/search?q=Madonna
+.. _Dexter: http://www.imdb.com/find?s=all&q=Dexter
+.. _Ponto de Impacto: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Ponto+de+Impacto
+.. _Polly Twitter Client: https://duckduckgo.com/?q=Polly+Twitter+Client
+.. _Universidade Federal de Minas Gerais: https://duckduckgo.com/?q=Universidade+Federal+de+Minas+Gerais
+.. _Evidosol: https://duckduckgo.com/?q=Evidosol
+.. _Revista Texto Livre: https://duckduckgo.com/?q=Revista+Texto+Livre
+.. _Ubuntu Brasil: https://duckduckgo.com/?q=Ubuntu+Brasil
+.. _Xoops: https://duckduckgo.com/?q=Xoops
+.. _Ubuntu Linux: https://duckduckgo.com/?q=Ubuntu+Linux
+.. _Underlinux: https://duckduckgo.com/?q=Underlinux
+.. _Kernel: https://duckduckgo.com/?q=Kernel
+.. _Ning: https://duckduckgo.com/?q=Ning
+.. _Moodle: https://duckduckgo.com/?q=Moodle
+.. _Software Livre Educacional: https://duckduckgo.com/?q=Software+Livre+Educacional
+.. _Associação Software Livre: https://duckduckgo.com/?q=Associação+Software+Livre
+.. _Portal do Professor Livre na Rede: https://duckduckgo.com/?q=Portal+do+Professor+Livre+na+Rede
+.. _Inteligência Artificial: https://duckduckgo.com/?q=Inteligência+Artificial
+.. _Inteligência Adaptiva: https://duckduckgo.com/?q=Inteligência+Adaptiva
+.. _Universidade de São Paulo: https://duckduckgo.com/?q=Universidade+de+São+Paulo
+.. _Kurt Kraut: https://duckduckgo.com/?q=Kurt+Kraut
+.. _UFBA: https://duckduckgo.com/?q=UFBA
+.. _UNESP: https://duckduckgo.com/?q=UNESP
+.. _Laboratório de Semiótica e Tecnologia: https://duckduckgo.com/?q=Laboratório+de+Semiótica+e+Tecnologia
+.. _FAPEMIG: https://duckduckgo.com/?q=FAPEMIG
+.. _Amadeus: http://amadeus.cin.ufpe.br/blog/
+.. _WordPress: https://duckduckgo.com/?q=WordPress
+.. _ULGG: https://duckduckgo.com/?q=ULGG
+.. _GT de Educação do FILS: https://duckduckgo.com/?q=GT+de+Educação+do+FILS
+.. _FISL: https://duckduckgo.com/?q=FISL
+.. _Praat: https://duckduckgo.com/?q=Praat
+.. _Fedora Linux: https://duckduckgo.com/?q=Fedora+Linux
+.. _Slackware Linux: https://duckduckgo.com/?q=Slackware+Linux
+.. _Brasnet: https://duckduckgo.com/?q=Brasnet
+.. _Freenode: https://duckduckgo.com/?q=Freenode
+.. _UML: https://duckduckgo.com/?q=UML
+.. _último episódio: http://wp.me/p1mMfJ-20
+.. _Sunday Night Learning: http://soundcloud.com/clebertsuconic/sunday-night-lerning
+.. _Clebert Suconic: http://soundcloud.com/clebertsuconic

--- a/content/episodes/030-rodrigo-belem-ubuntu-brasil.rst
+++ b/content/episodes/030-rodrigo-belem-ubuntu-brasil.rst
@@ -64,68 +64,129 @@ Resumo
 
 Top 5
 -----
--  **Música:** `The Advantage <http://www.last.fm/search?q=The+Advantage>`__
--  **Música:** `Antônio Pereira <http://www.last.fm/search?q=Antônio+Pereira>`__
--  **Música:** `Geraldo Azevedo <http://www.last.fm/search?q=Geraldo+Azevedo>`__
--  **Música:** `Oswaldo Montenegro <http://www.last.fm/search?q=Oswaldo+Montenegro>`__
--  **Filmes:** `Encontro Marcado <http://www.imdb.com/find?s=all&q=Encontro+Marcado>`__
--  **Filmes:** `Supernatural <http://www.imdb.com/find?s=all&q=Supernatural>`__
--  **Filmes:** `Dexter <http://www.imdb.com/find?s=all&q=Dexter>`__
--  **Filmes:** `Battlestar Gallactica <http://www.imdb.com/find?s=all&q=Battlestar+Gallactica>`__
--  **Filmes:** `Doctor Who <http://www.imdb.com/find?s=all&q=Doctor+Who>`__
--  **Filmes:** `Monty Python <http://www.imdb.com/find?s=all&q=Monty+Python>`__
--  **Livros:** `Natural Language Processing with Python <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Natural+Language+Processing+with+Python>`__
--  **Livros:** `Guía do Muchileiro das Galáxias <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Guia+do+Muchileiro+das+Galáxias>`__
--  **Livros:** `Cavalo de Tróia <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Cavalo+de+Tróia>`__
--  **Livros:** `Tom Venuto <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Tom+Venuto>`__
+-  **Música:** `The Advantage`_
+-  **Música:** `Antônio Pereira`_
+-  **Música:** `Geraldo Azevedo`_
+-  **Música:** `Oswaldo Montenegro`_
+-  **Filmes:** `Encontro Marcado`_
+-  **Filmes:** `Supernatural`_
+-  **Filmes:** `Dexter`_
+-  **Filmes:** `Battlestar Gallactica`_
+-  **Filmes:** `Doctor Who`_
+-  **Filmes:** `Monty Python`_
+-  **Livros:** `Natural Language Processing with Python`_
+-  **Livros:** `Guía do Muchileiro das Galáxias`_
+-  **Livros:** `Cavalo de Tróia`_
+-  **Livros:** `Tom Venuto`_
 
 Links
 -----
--  `Ian Lawrence <https://duckduckgo.com/?q=Ian+Lawrence>`__
--  `Carlos "segfault" Santiviago <https://duckduckgo.com/?q=Carlos+>`__
--  `DebConf <https://duckduckgo.com/?q=DebConf>`__
--  `Mark Shuttleworth <https://duckduckgo.com/?q=Mark+Shuttleworth>`__
--  `Benjamin Mako Hill <https://duckduckgo.com/?q=Benjamin+Mako+Hill>`__
--  `Ubuntu Summit <https://duckduckgo.com/?q=Ubuntu+Summit>`__
--  `Debian Amazonas <https://duckduckgo.com/?q=Debian+Amazonas>`__
--  `Ubuntu Linux <https://duckduckgo.com/?q=Ubuntu+Linux>`__
--  `Debian Linux <https://duckduckgo.com/?q=Debian+Linux>`__
--  `Mário Meyer <https://duckduckgo.com/?q=Mário+Meyer>`__
--  `Marcelo Mendes <https://duckduckgo.com/?q=Marcelo+Mendes>`__
--  `Emerson Soares <https://duckduckgo.com/?q=Emerson+Soares>`__
--  `ShiptIt <https://duckduckgo.com/?q=ShiptIt>`__
--  `Lício Fonseca <https://duckduckgo.com/?q=Lício+Fonseca>`__
--  `Fábio Nogueira <https://duckduckgo.com/?q=Fábio+Nogueira>`__
--  `Rafel Proença <https://duckduckgo.com/?q=Rafel+Proença>`__
--  `Roberto Mello <https://duckduckgo.com/?q=Roberto+Mello>`__
--  `Perl <https://duckduckgo.com/?q=Perl>`__
--  `Bash <https://duckduckgo.com/?q=Bash>`__
--  `KDE <https://duckduckgo.com/?q=KDE>`__
--  `Indp <https://duckduckgo.com/?q=Indp>`__
--  `Kubuntu <https://duckduckgo.com/?q=Kubuntu>`__
--  `Ubuntu Mobile <https://duckduckgo.com/?q=Ubuntu+Mobile>`__
--  `Plasma <https://duckduckgo.com/?q=Plasma>`__
--  `Licença GPL <https://duckduckgo.com/?q=Licença+GPL>`__
--  `Licença MIT <https://duckduckgo.com/?q=Licença+MIT>`__
--  `Postology <https://duckduckgo.com/?q=Postology>`__
--  `Python <https://duckduckgo.com/?q=Python>`__
--  `Python NLTK <https://duckduckgo.com/?q=Python+NLTK>`__
--  `File Sharing <https://duckduckgo.com/?q=File+Sharing>`__
--  `Intel <https://duckduckgo.com/?q=Intel>`__
--  `Professional Ubuntu Mobile Development <https://duckduckgo.com/?q=Professional+Ubuntu+Mobile+Development>`__
--  `UMEGuide.net <https://duckduckgo.com/?q=UMEGuide.net>`__
--  `Linaro <https://duckduckgo.com/?q=Linaro>`__
--  `ARM <https://duckduckgo.com/?q=ARM>`__
--  `Ubuntu Business Remix <https://duckduckgo.com/?q=Ubuntu+Business+Remix>`__
--  `Windows <https://duckduckgo.com/?q=Windows>`__
--  `MacOS <https://duckduckgo.com/?q=MacOS>`__
--  `Slackware Linux <https://duckduckgo.com/?q=Slackware+Linux>`__
--  `Arch Linux <https://duckduckgo.com/?q=Arch+Linux>`__
--  `Unity <https://duckduckgo.com/?q=Unity>`__
--  `GNOME <https://duckduckgo.com/?q=GNOME>`__
--  `Jonathan Riddell <https://duckduckgo.com/?q=Jonathan+Riddell>`__
--  `Netflix <https://duckduckgo.com/?q=Netflix>`__
+-  `Ian Lawrence`_
+-  `Carlos "segfault" Santiviago`_
+-  `DebConf`_
+-  `Mark Shuttleworth`_
+-  `Benjamin Mako Hill`_
+-  `Ubuntu Summit`_
+-  `Debian Amazonas`_
+-  `Ubuntu Linux`_
+-  `Debian Linux`_
+-  `Mário Meyer`_
+-  `Marcelo Mendes`_
+-  `Emerson Soares`_
+-  `ShiptIt`_
+-  `Lício Fonseca`_
+-  `Fábio Nogueira`_
+-  `Rafel Proença`_
+-  `Roberto Mello`_
+-  `Perl`_
+-  `Bash`_
+-  `KDE`_
+-  `Indp`_
+-  `Kubuntu`_
+-  `Ubuntu Mobile`_
+-  `Plasma`_
+-  `Licença GPL`_
+-  `Licença MIT`_
+-  `Postology`_
+-  `Python`_
+-  `Python NLTK`_
+-  `File Sharing`_
+-  `Intel`_
+-  `Professional Ubuntu Mobile Development`_
+-  `UMEGuide.net`_
+-  `Linaro`_
+-  `ARM`_
+-  `Ubuntu Business Remix`_
+-  `Windows`_
+-  `MacOS`_
+-  `Slackware Linux`_
+-  `Arch Linux`_
+-  `Unity`_
+-  `GNOME`_
+-  `Jonathan Riddell`_
+-  `Netflix`_
 
 .. class:: panel-body bg-info
 
-        **Música**: `Sunday Night Learning <http://soundcloud.com/clebertsuconic/sunday-night-lerning>`__ por `Clebert Suconic <http://soundcloud.com/clebertsuconic>`__.*
+        **Música**: `Sunday Night Learning`_ por `Clebert Suconic`_.*
+
+.. _The Advantage: http://www.last.fm/search?q=The+Advantage
+.. _Antônio Pereira: http://www.last.fm/search?q=Antônio+Pereira
+.. _Geraldo Azevedo: http://www.last.fm/search?q=Geraldo+Azevedo
+.. _Oswaldo Montenegro: http://www.last.fm/search?q=Oswaldo+Montenegro
+.. _Encontro Marcado: http://www.imdb.com/find?s=all&q=Encontro+Marcado
+.. _Supernatural: http://www.imdb.com/find?s=all&q=Supernatural
+.. _Dexter: http://www.imdb.com/find?s=all&q=Dexter
+.. _Battlestar Gallactica: http://www.imdb.com/find?s=all&q=Battlestar+Gallactica
+.. _Doctor Who: http://www.imdb.com/find?s=all&q=Doctor+Who
+.. _Monty Python: http://www.imdb.com/find?s=all&q=Monty+Python
+.. _Natural Language Processing with Python: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Natural+Language+Processing+with+Python
+.. _Guía do Muchileiro das Galáxias: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Guia+do+Muchileiro+das+Galáxias
+.. _Cavalo de Tróia: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Cavalo+de+Tróia
+.. _Tom Venuto: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Tom+Venuto
+.. _Ian Lawrence: https://duckduckgo.com/?q=Ian+Lawrence
+.. _Carlos "segfault" Santiviago: https://duckduckgo.com/?q=Carlos+
+.. _DebConf: https://duckduckgo.com/?q=DebConf
+.. _Mark Shuttleworth: https://duckduckgo.com/?q=Mark+Shuttleworth
+.. _Benjamin Mako Hill: https://duckduckgo.com/?q=Benjamin+Mako+Hill
+.. _Ubuntu Summit: https://duckduckgo.com/?q=Ubuntu+Summit
+.. _Debian Amazonas: https://duckduckgo.com/?q=Debian+Amazonas
+.. _Ubuntu Linux: https://duckduckgo.com/?q=Ubuntu+Linux
+.. _Debian Linux: https://duckduckgo.com/?q=Debian+Linux
+.. _Mário Meyer: https://duckduckgo.com/?q=Mário+Meyer
+.. _Marcelo Mendes: https://duckduckgo.com/?q=Marcelo+Mendes
+.. _Emerson Soares: https://duckduckgo.com/?q=Emerson+Soares
+.. _ShiptIt: https://duckduckgo.com/?q=ShiptIt
+.. _Lício Fonseca: https://duckduckgo.com/?q=Lício+Fonseca
+.. _Fábio Nogueira: https://duckduckgo.com/?q=Fábio+Nogueira
+.. _Rafel Proença: https://duckduckgo.com/?q=Rafel+Proença
+.. _Roberto Mello: https://duckduckgo.com/?q=Roberto+Mello
+.. _Perl: https://duckduckgo.com/?q=Perl
+.. _Bash: https://duckduckgo.com/?q=Bash
+.. _KDE: https://duckduckgo.com/?q=KDE
+.. _Indp: https://duckduckgo.com/?q=Indp
+.. _Kubuntu: https://duckduckgo.com/?q=Kubuntu
+.. _Ubuntu Mobile: https://duckduckgo.com/?q=Ubuntu+Mobile
+.. _Plasma: https://duckduckgo.com/?q=Plasma
+.. _Licença GPL: https://duckduckgo.com/?q=Licença+GPL
+.. _Licença MIT: https://duckduckgo.com/?q=Licença+MIT
+.. _Postology: https://duckduckgo.com/?q=Postology
+.. _Python: https://duckduckgo.com/?q=Python
+.. _Python NLTK: https://duckduckgo.com/?q=Python+NLTK
+.. _File Sharing: https://duckduckgo.com/?q=File+Sharing
+.. _Intel: https://duckduckgo.com/?q=Intel
+.. _Professional Ubuntu Mobile Development: https://duckduckgo.com/?q=Professional+Ubuntu+Mobile+Development
+.. _UMEGuide.net: https://duckduckgo.com/?q=UMEGuide.net
+.. _Linaro: https://duckduckgo.com/?q=Linaro
+.. _ARM: https://duckduckgo.com/?q=ARM
+.. _Ubuntu Business Remix: https://duckduckgo.com/?q=Ubuntu+Business+Remix
+.. _Windows: https://duckduckgo.com/?q=Windows
+.. _MacOS: https://duckduckgo.com/?q=MacOS
+.. _Slackware Linux: https://duckduckgo.com/?q=Slackware+Linux
+.. _Arch Linux: https://duckduckgo.com/?q=Arch+Linux
+.. _Unity: https://duckduckgo.com/?q=Unity
+.. _GNOME: https://duckduckgo.com/?q=GNOME
+.. _Jonathan Riddell: https://duckduckgo.com/?q=Jonathan+Riddell
+.. _Netflix: https://duckduckgo.com/?q=Netflix
+.. _Sunday Night Learning: http://soundcloud.com/clebertsuconic/sunday-night-lerning
+.. _Clebert Suconic: http://soundcloud.com/clebertsuconic

--- a/content/episodes/031-ivan-brasil-fuzzer-ubuntero.rst
+++ b/content/episodes/031-ivan-brasil-fuzzer-ubuntero.rst
@@ -18,16 +18,14 @@ com uma equipe de colaboradores, o Ivan escreve artigos sobre todas as
 áreas relacionadas à tecnologia e tutorias, focando na área de software
 livre!
 
-A história do Ubuntero me lembra um pouco a história do
-`BR-Linux <http://br-linux.org/>`__, começando como um catálogo de
-informações úteis para o Ivan e eventualmente tornando-se em um ponto de
-parada para todos aqueles usuários de Linux que procuram dicas e truques
-para lidarem com suas configurações.
+A história do Ubuntero me lembra um pouco a história do `BR-Linux`_, começando
+como um catálogo de informações úteis para o Ivan e eventualmente tornando-se
+em um ponto de parada para todos aqueles usuários de Linux que procuram dicas
+e truques para lidarem com suas configurações.
 
-Com o passar dos tempos seu projeto deixou de ser somente "mais um blog
-sobre Linux" e expandiu para outras vias de comunicação, como um `canal
-de vídeos <http://www.youtube.com/user/ubunterobr?feature=watch>`__ no
-**Youtube** e seu mais recente projeto, o **Opencast** podcast!
+Com o passar dos tempos seu projeto deixou de ser somente "mais um blog sobre
+Linux" e expandiu para outras vias de comunicação, como um `canal de vídeos`_
+no **Youtube** e seu mais recente projeto, o **Opencast** podcast!
 
 .. more
 
@@ -39,8 +37,7 @@ conteúdo de seus projetos, planos para o futuro, terminando com a sua
 previsão para o Ubuntu Linux em 2012!
 
 Ah, e mudei a "trilha sonora" do podcast de volta ao tema anterior a
-pedido do meu amigo `Reinaldo
-Bispo <https://twitter.com/#!/corvolinoPUNK>`__! :)
+pedido do meu amigo `Reinaldo Bispo`_! :)
 
 Escute Agora
 ------------
@@ -70,52 +67,52 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Cesar Oliveira <http://www.last.fm/search?q=Cesar+Oliveira>`__
--  **Música:** `Rogério Melo <http://www.last.fm/search?q=Rogério+Melo>`__
--  **Música:** `Neto Fagundes <http://www.last.fm/search?q=Neto+Fagundes>`__
--  **Música:** `Piresca Greco <http://www.last.fm/search?q=Piresca+Greco>`__
--  **Música:** `Iron Madden <http://www.last.fm/search?q=Iron+Madden>`__
--  **Música:** `AC/DC <http://www.last.fm/search?q=AC/DC>`__
--  **Música:** `Mettalica <http://www.last.fm/search?q=Mettalica>`__
--  **Música:** `Ludwig van Beethoven <http://www.last.fm/search?q=Ludwig+van+Beethoven>`__
--  **Música:** `Cidadão Quem <http://www.last.fm/search?q=Cidadão+Quem>`__
--  **Música:** `Capital Inicial <http://www.last.fm/search?q=Capital+Inicial>`__
--  **Filmes:** `The Walking Dead <http://www.imdb.com/find?s=all&q=The+Walking+Dead>`__
--  **Filmes:** `Inception <http://www.imdb.com/find?s=all&q=Inception>`__
--  **Filmes:** `The Matrix <http://www.imdb.com/find?s=all&q=The+Matrix>`__
--  **Filmes:** `Animatrix <http://www.imdb.com/find?s=all&q=Animatrix>`__
--  **Livros:** `Filhos do Éden <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Filhos+do+Éden>`__
--  **Livros:** `Batalha do Apocalipse <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Batalha+do+Apocalipse>`__
+-  **Música:** `Cesar Oliveira`_
+-  **Música:** `Rogério Melo`_
+-  **Música:** `Neto Fagundes`_
+-  **Música:** `Piresca Greco`_
+-  **Música:** `Iron Madden`_
+-  **Música:** `AC/DC`_
+-  **Música:** `Mettalica`_
+-  **Música:** `Ludwig van Beethoven`_
+-  **Música:** `Cidadão Quem`_
+-  **Música:** `Capital Inicial`_
+-  **Filmes:** `The Walking Dead`_
+-  **Filmes:** `Inception`_
+-  **Filmes:** `The Matrix`_
+-  **Filmes:** `Animatrix`_
+-  **Livros:** `Filhos do Éden`_
+-  **Livros:** `Batalha do Apocalipse`_
 
 Links
 -----
--  `Ubuntu Linux <https://duckduckgo.com/?q=Ubuntu+Linux>`__
--  `Ubuntero <https://duckduckgo.com/?q=Ubuntero>`__
--  `OpenCast <https://duckduckgo.com/?q=OpenCast>`__
--  `Twitter <https://duckduckgo.com/?q=Twitter>`__
--  `Debian Linux <https://duckduckgo.com/?q=Debian+Linux>`__
--  `Grupo Caudílho Livre <https://duckduckgo.com/?q=Grupo+Caudílho+Livre>`__
--  `Youtube <https://duckduckgo.com/?q=Youtube>`__
--  `GtkRecordMyDesktop <https://duckduckgo.com/?q=GtkRecordMyDesktop>`__
--  `KDenlive <https://duckduckgo.com/?q=KDenlive>`__
--  `Cinelera <https://duckduckgo.com/?q=Cinelera>`__
--  `Openshot <https://duckduckgo.com/?q=Openshot>`__
--  `Skype <https://duckduckgo.com/?q=Skype>`__
--  `Skype Call Recorder <https://duckduckgo.com/?q=Skype+Call+Recorder>`__
--  `Audacity <https://duckduckgo.com/?q=Audacity>`__
--  `Delphi <https://duckduckgo.com/?q=Delphi>`__
--  `Shell Script <https://duckduckgo.com/?q=Shell+Script>`__
--  `C++ <https://duckduckgo.com/?q=C++>`__
--  `Java <https://duckduckgo.com/?q=Java>`__
--  `Cobol <https://duckduckgo.com/?q=Cobol>`__
--  `List <https://duckduckgo.com/?q=List>`__
--  `Assembly <https://duckduckgo.com/?q=Assembly>`__
--  `Eduardo Spohr <https://duckduckgo.com/?q=Eduardo+Spohr>`__
--  `Vim <https://duckduckgo.com/?q=Vim>`__
--  `W32 Codecs <https://duckduckgo.com/?q=W32+Codecs>`__
--  `Mozilla Thunderbird <https://duckduckgo.com/?q=Mozilla+Thunderbird>`__
--  `Virtual Box <https://duckduckgo.com/?q=Virtual+Box>`__
--  `Ubuntu Unity <https://duckduckgo.com/?q=Ubuntu+Unity>`__
+-  `Ubuntu Linux`_
+-  `Ubuntero`_
+-  `OpenCast`_
+-  `Twitter`_
+-  `Debian Linux`_
+-  `Grupo Caudílho Livre`_
+-  `Youtube`_
+-  `GtkRecordMyDesktop`_
+-  `KDenlive`_
+-  `Cinelera`_
+-  `Openshot`_
+-  `Skype`_
+-  `Skype Call Recorder`_
+-  `Audacity`_
+-  `Delphi`_
+-  `Shell Script`_
+-  `C++`_
+-  `Java`_
+-  `Cobol`_
+-  `List`_
+-  `Assembly`_
+-  `Eduardo Spohr`_
+-  `Vim`_
+-  `W32 Codecs`_
+-  `Mozilla Thunderbird`_
+-  `Virtual Box`_
+-  `Ubuntu Unity`_
 
 .. class:: panel-body bg-info
 
@@ -124,3 +121,49 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _BR-Linux: http://br-linux.org/
+.. _canal de vídeos: http://www.youtube.com/user/ubunterobr?feature=watch
+.. _Reinaldo Bispo: https://twitter.com/#!/corvolinoPUNK
+.. _Cesar Oliveira: http://www.last.fm/search?q=Cesar+Oliveira
+.. _Rogério Melo: http://www.last.fm/search?q=Rogério+Melo
+.. _Neto Fagundes: http://www.last.fm/search?q=Neto+Fagundes
+.. _Piresca Greco: http://www.last.fm/search?q=Piresca+Greco
+.. _Iron Madden: http://www.last.fm/search?q=Iron+Madden
+.. _AC/DC: http://www.last.fm/search?q=AC/DC
+.. _Mettalica: http://www.last.fm/search?q=Mettalica
+.. _Ludwig van Beethoven: http://www.last.fm/search?q=Ludwig+van+Beethoven
+.. _Cidadão Quem: http://www.last.fm/search?q=Cidadão+Quem
+.. _Capital Inicial: http://www.last.fm/search?q=Capital+Inicial
+.. _The Walking Dead: http://www.imdb.com/find?s=all&q=The+Walking+Dead
+.. _Inception: http://www.imdb.com/find?s=all&q=Inception
+.. _The Matrix: http://www.imdb.com/find?s=all&q=The+Matrix
+.. _Animatrix: http://www.imdb.com/find?s=all&q=Animatrix
+.. _Filhos do Éden: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Filhos+do+Éden
+.. _Batalha do Apocalipse: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Batalha+do+Apocalipse
+.. _Ubuntu Linux: https://duckduckgo.com/?q=Ubuntu+Linux
+.. _Ubuntero: https://duckduckgo.com/?q=Ubuntero
+.. _OpenCast: https://duckduckgo.com/?q=OpenCast
+.. _Twitter: https://duckduckgo.com/?q=Twitter
+.. _Debian Linux: https://duckduckgo.com/?q=Debian+Linux
+.. _Grupo Caudílho Livre: https://duckduckgo.com/?q=Grupo+Caudílho+Livre
+.. _Youtube: https://duckduckgo.com/?q=Youtube
+.. _GtkRecordMyDesktop: https://duckduckgo.com/?q=GtkRecordMyDesktop
+.. _KDenlive: https://duckduckgo.com/?q=KDenlive
+.. _Cinelera: https://duckduckgo.com/?q=Cinelera
+.. _Openshot: https://duckduckgo.com/?q=Openshot
+.. _Skype: https://duckduckgo.com/?q=Skype
+.. _Skype Call Recorder: https://duckduckgo.com/?q=Skype+Call+Recorder
+.. _Audacity: https://duckduckgo.com/?q=Audacity
+.. _Delphi: https://duckduckgo.com/?q=Delphi
+.. _Shell Script: https://duckduckgo.com/?q=Shell+Script
+.. _C++: https://duckduckgo.com/?q=C++
+.. _Java: https://duckduckgo.com/?q=Java
+.. _Cobol: https://duckduckgo.com/?q=Cobol
+.. _List: https://duckduckgo.com/?q=List
+.. _Assembly: https://duckduckgo.com/?q=Assembly
+.. _Eduardo Spohr: https://duckduckgo.com/?q=Eduardo+Spohr
+.. _Vim: https://duckduckgo.com/?q=Vim
+.. _W32 Codecs: https://duckduckgo.com/?q=W32+Codecs
+.. _Mozilla Thunderbird: https://duckduckgo.com/?q=Mozilla+Thunderbird
+.. _Virtual Box: https://duckduckgo.com/?q=Virtual+Box
+.. _Ubuntu Unity: https://duckduckgo.com/?q=Ubuntu+Unity

--- a/content/episodes/032-gabriel-falcao-yipit.rst
+++ b/content/episodes/032-gabriel-falcao-yipit.rst
@@ -65,76 +65,76 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Strokes <http://www.last.fm/search?q=Strokes>`__
--  **Música:** `White Stripes <http://www.last.fm/search?q=White+Stripes>`__
--  **Música:** `MGMT <http://www.last.fm/search?q=MGMT>`__
--  **Música:** `Two Door Cinema Club <http://www.last.fm/search?q=Two+Door+Cinema+Club>`__
--  **Música:** `Daft Punk <http://www.last.fm/search?q=Daft+Punk>`__
--  **Filmes:** `White Collar <http://www.imdb.com/find?s=all&q=White+Collar>`__
--  **Filmes:** `Big Band Theory <http://www.imdb.com/find?s=all&q=Big+Band+Theory>`__
--  **Filmes:** `Dexter <http://www.imdb.com/find?s=all&q=Dexter>`__
--  **Filmes:** `Guy Ritchie <http://www.imdb.com/find?s=all&q=Guy+Ritchie>`__
--  **Filmes:** `Sherlock Holmes <http://www.imdb.com/find?s=all&q=Sherlock+Holmes>`__
--  **Filmes:** `Lock, Stock and Two Smoking Barrels <http://www.imdb.com/find?s=all&q=Lock,+Stock+and+Two+Smoking+Barrels>`__
--  **Filmes:** `Jogos Mortais <http://www.imdb.com/find?s=all&q=Jogos+Mortais>`__
--  **Livros:** `HBase <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=HBase>`__
+-  **Música:** `Strokes`_
+-  **Música:** `White Stripes`_
+-  **Música:** `MGMT`_
+-  **Música:** `Two Door Cinema Club`_
+-  **Música:** `Daft Punk`_
+-  **Filmes:** `White Collar`_
+-  **Filmes:** `Big Band Theory`_
+-  **Filmes:** `Dexter`_
+-  **Filmes:** `Guy Ritchie`_
+-  **Filmes:** `Sherlock Holmes`_
+-  **Filmes:** `Lock, Stock and Two Smoking Barrels`_
+-  **Filmes:** `Jogos Mortais`_
+-  **Livros:** `HBase`_
 
 Links
 -----
--  `Guake <https://duckduckgo.com/?q=Guake>`__
--  `Tilda <https://duckduckgo.com/?q=Tilda>`__
--  `Yakauke <https://duckduckgo.com/?q=Yakauke>`__
--  `YipIt <http://yipit.com/>`__
--  `Django <https://duckduckgo.com/?q=Django>`__
--  `Linguagem Python <https://duckduckgo.com/?q=Linguagem+Python>`__
--  `GNU/Linux <https://duckduckgo.com/?q=GNU/Linux>`__
--  `Debian Linux <https://duckduckgo.com/?q=Debian+Linux>`__
--  `Ubuntu Linux <https://duckduckgo.com/?q=Ubuntu+Linux>`__
--  `KDE <https://duckduckgo.com/?q=KDE>`__
--  `Windows <https://duckduckgo.com/?q=Windows>`__
--  `GNOME <https://duckduckgo.com/?q=GNOME>`__
--  `GLib <https://duckduckgo.com/?q=GLib>`__
--  `Qt <https://duckduckgo.com/?q=Qt>`__
--  `Gtk <https://duckduckgo.com/?q=Gtk>`__
--  `Belo Horizonte <https://duckduckgo.com/?q=Belo+Horizonte>`__
--  `Software Livre <https://duckduckgo.com/?q=Software+Livre>`__
--  `Licença GPL <https://duckduckgo.com/?q=Licença+GPL>`__
--  `Licença MIT <https://duckduckgo.com/?q=Licença+MIT>`__
--  `Servidor Apache <https://duckduckgo.com/?q=Servidor+Apache>`__
--  `Banco do Brasil <https://duckduckgo.com/?q=Banco+do+Brasil>`__
--  `Globo.com <https://duckduckgo.com/?q=Globo.com>`__
--  `Mac OS <https://duckduckgo.com/?q=Mac+OS>`__
--  `Github <https://duckduckgo.com/?q=Github>`__
--  `Uncle Bob <https://github.com/gabrielfalcao/unclebob>`__
--  `Lettuce <https://github.com/gabrielfalcao/lettuce>`__
--  `HTTPretty <https://github.com/gabrielfalcao/HTTPretty>`__
--  `Salad <https://github.com/gabrielfalcao/salad>`__
--  `Little Joy <https://github.com/gabrielfalcao/LittleJoy>`__
--  `dead-parrot <https://github.com/gabrielfalcao/dead-parrot>`__
--  `Bolacha <https://github.com/gabrielfalcao/bolacha>`__
--  `Desenvolvimento Agile <https://duckduckgo.com/?q=Desenvolvimento+Agile>`__
--  `Técnica Scrum <https://duckduckgo.com/?q=Técnica+Scrum>`__
--  `Pyccuracy <https://github.com/heynemann/pyccuracy>`__
--  `Bernardo Heynemann <https://github.com/heynemann>`__
--  `C# <https://duckduckgo.com/?q=C#>`__
--  `Selenium <https://duckduckgo.com/?q=Selenium>`__
--  `Linguagem Ruby <https://duckduckgo.com/?q=Linguagem+Ruby>`__
--  `Cucumber <https://duckduckgo.com/?q=Cucumber>`__
--  `Capybara <https://duckduckgo.com/?q=Capybara>`__
--  `Banda Lettuce <https://duckduckgo.com/?q=Banda+Lettuce>`__
--  `RSpec <https://duckduckgo.com/?q=RSpec>`__
--  `Teste unitário <https://duckduckgo.com/?q=Teste+unitário>`__
--  `Behavior Driven Development <https://duckduckgo.com/?q=Behavior+Driven+Development>`__
--  `Groupon <https://duckduckgo.com/?q=Groupon>`__
--  `Peixe Urbano <https://duckduckgo.com/?q=Peixe+Urbano>`__
--  `Integração contínua <https://duckduckgo.com/?q=Integração+contínua>`__
--  `Jenkins <https://duckduckgo.com/?q=Jenkins>`__
--  `Bamboo <https://duckduckgo.com/?q=Bamboo>`__
--  `Node.js <https://duckduckgo.com/?q=Node.js>`__
--  `Socket.IO <https://duckduckgo.com/?q=Socket.IO>`__
--  `DebConf <https://duckduckgo.com/?q=DebConf>`__
--  `DjangoCon <https://duckduckgo.com/?q=DjangoCon>`__
--  `Music For Programming <http://musicforprogramming.net/>`__
+-  `Guake`_
+-  `Tilda`_
+-  `Yakauke`_
+-  `YipIt`_
+-  `Django`_
+-  `Linguagem Python`_
+-  `GNU/Linux`_
+-  `Debian Linux`_
+-  `Ubuntu Linux`_
+-  `KDE`_
+-  `Windows`_
+-  `GNOME`_
+-  `GLib`_
+-  `Qt`_
+-  `Gtk`_
+-  `Belo Horizonte`_
+-  `Software Livre`_
+-  `Licença GPL`_
+-  `Licença MIT`_
+-  `Servidor Apache`_
+-  `Banco do Brasil`_
+-  `Globo.com`_
+-  `Mac OS`_
+-  `Github`_
+-  `Uncle Bob`_
+-  `Lettuce`_
+-  `HTTPretty`_
+-  `Salad`_
+-  `Little Joy`_
+-  `dead-parrot`_
+-  `Bolacha`_
+-  `Desenvolvimento Agile`_
+-  `Técnica Scrum`_
+-  `Pyccuracy`_
+-  `Bernardo Heynemann`_
+-  `C#`_
+-  `Selenium`_
+-  `Linguagem Ruby`_
+-  `Cucumber`_
+-  `Capybara`_
+-  `Banda Lettuce`_
+-  `RSpec`_
+-  `Teste unitário`_
+-  `Behavior Driven Development`_
+-  `Groupon`_
+-  `Peixe Urbano`_
+-  `Integração contínua`_
+-  `Jenkins`_
+-  `Bamboo`_
+-  `Node.js`_
+-  `Socket.IO`_
+-  `DebConf`_
+-  `DjangoCon`_
+-  `Music For Programming`_
 
 .. class:: panel-body bg-info
 
@@ -143,3 +143,70 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _Strokes: http://www.last.fm/search?q=Strokes
+.. _White Stripes: http://www.last.fm/search?q=White+Stripes
+.. _MGMT: http://www.last.fm/search?q=MGMT
+.. _Two Door Cinema Club: http://www.last.fm/search?q=Two+Door+Cinema+Club
+.. _Daft Punk: http://www.last.fm/search?q=Daft+Punk
+.. _White Collar: http://www.imdb.com/find?s=all&q=White+Collar
+.. _Big Band Theory: http://www.imdb.com/find?s=all&q=Big+Band+Theory
+.. _Dexter: http://www.imdb.com/find?s=all&q=Dexter
+.. _Guy Ritchie: http://www.imdb.com/find?s=all&q=Guy+Ritchie
+.. _Sherlock Holmes: http://www.imdb.com/find?s=all&q=Sherlock+Holmes
+.. _Lock, Stock and Two Smoking Barrels: http://www.imdb.com/find?s=all&q=Lock,+Stock+and+Two+Smoking+Barrels
+.. _Jogos Mortais: http://www.imdb.com/find?s=all&q=Jogos+Mortais
+.. _HBase: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=HBase
+.. _Guake: https://duckduckgo.com/?q=Guake
+.. _Tilda: https://duckduckgo.com/?q=Tilda
+.. _Yakauke: https://duckduckgo.com/?q=Yakauke
+.. _YipIt: http://yipit.com/
+.. _Django: https://duckduckgo.com/?q=Django
+.. _Linguagem Python: https://duckduckgo.com/?q=Linguagem+Python
+.. _GNU/Linux: https://duckduckgo.com/?q=GNU/Linux
+.. _Debian Linux: https://duckduckgo.com/?q=Debian+Linux
+.. _Ubuntu Linux: https://duckduckgo.com/?q=Ubuntu+Linux
+.. _KDE: https://duckduckgo.com/?q=KDE
+.. _Windows: https://duckduckgo.com/?q=Windows
+.. _GNOME: https://duckduckgo.com/?q=GNOME
+.. _GLib: https://duckduckgo.com/?q=GLib
+.. _Qt: https://duckduckgo.com/?q=Qt
+.. _Gtk: https://duckduckgo.com/?q=Gtk
+.. _Belo Horizonte: https://duckduckgo.com/?q=Belo+Horizonte
+.. _Software Livre: https://duckduckgo.com/?q=Software+Livre
+.. _Licença GPL: https://duckduckgo.com/?q=Licença+GPL
+.. _Licença MIT: https://duckduckgo.com/?q=Licença+MIT
+.. _Servidor Apache: https://duckduckgo.com/?q=Servidor+Apache
+.. _Banco do Brasil: https://duckduckgo.com/?q=Banco+do+Brasil
+.. _Globo.com: https://duckduckgo.com/?q=Globo.com
+.. _Mac OS: https://duckduckgo.com/?q=Mac+OS
+.. _Github: https://duckduckgo.com/?q=Github
+.. _Uncle Bob: https://github.com/gabrielfalcao/unclebob
+.. _Lettuce: https://github.com/gabrielfalcao/lettuce
+.. _HTTPretty: https://github.com/gabrielfalcao/HTTPretty
+.. _Salad: https://github.com/gabrielfalcao/salad
+.. _Little Joy: https://github.com/gabrielfalcao/LittleJoy
+.. _dead-parrot: https://github.com/gabrielfalcao/dead-parrot
+.. _Bolacha: https://github.com/gabrielfalcao/bolacha
+.. _Desenvolvimento Agile: https://duckduckgo.com/?q=Desenvolvimento+Agile
+.. _Técnica Scrum: https://duckduckgo.com/?q=Técnica+Scrum
+.. _Pyccuracy: https://github.com/heynemann/pyccuracy
+.. _Bernardo Heynemann: https://github.com/heynemann
+.. _C#: https://duckduckgo.com/?q=C#
+.. _Selenium: https://duckduckgo.com/?q=Selenium
+.. _Linguagem Ruby: https://duckduckgo.com/?q=Linguagem+Ruby
+.. _Cucumber: https://duckduckgo.com/?q=Cucumber
+.. _Capybara: https://duckduckgo.com/?q=Capybara
+.. _Banda Lettuce: https://duckduckgo.com/?q=Banda+Lettuce
+.. _RSpec: https://duckduckgo.com/?q=RSpec
+.. _Teste unitário: https://duckduckgo.com/?q=Teste+unitário
+.. _Behavior Driven Development: https://duckduckgo.com/?q=Behavior+Driven+Development
+.. _Groupon: https://duckduckgo.com/?q=Groupon
+.. _Peixe Urbano: https://duckduckgo.com/?q=Peixe+Urbano
+.. _Integração contínua: https://duckduckgo.com/?q=Integração+contínua
+.. _Jenkins: https://duckduckgo.com/?q=Jenkins
+.. _Bamboo: https://duckduckgo.com/?q=Bamboo
+.. _Node.js: https://duckduckgo.com/?q=Node.js
+.. _Socket.IO: https://duckduckgo.com/?q=Socket.IO
+.. _DebConf: https://duckduckgo.com/?q=DebConf
+.. _DjangoCon: https://duckduckgo.com/?q=DjangoCon
+.. _Music For Programming: http://musicforprogramming.net/

--- a/content/episodes/033-henrique-bastos-welcome-to-the-django.rst
+++ b/content/episodes/033-henrique-bastos-welcome-to-the-django.rst
@@ -28,18 +28,16 @@ nasceu e evoluiu.
 
 .. more
 
-Durante nosso bate-papo o Henrique nos conta sobre o seu projeto e como
-que invés de ensinar o be-a-bá, ele usa e abusa de técnicas de
-desenvolvimento ágil, deployment first, **Heroku**, **Github** e muita
-interação para uma experiência rica e didática de dar inveja a muitos
-cursos por ai! Depois ele conta como que nasceu a Dekode, sua companhia
-de desenvolvedores "**black belt**\ " criada para providenciar um
-serviço de apoio "nível 2" para aquelas horas do aperto. Também falamos
-sobre a comunidade **Python** do Brasil, `Small Acts
-<http://smallactsmanifesto.org/>`__, apresentações pelos Estados
-Unidos, `revista INPUT <http://www.datacassete.com.br/>`__ (quem já teve
-um computador **TK85** ou **ZX Spectrum** sabe do que estou falando), e
-mais um monte coisas bacanas!
+Durante nosso bate-papo o Henrique nos conta sobre o seu projeto e como que
+invés de ensinar o be-a-bá, ele usa e abusa de técnicas de desenvolvimento
+ágil, deployment first, **Heroku**, **Github** e muita interação para uma
+experiência rica e didática de dar inveja a muitos cursos por ai! Depois ele
+conta como que nasceu a Dekode, sua companhia de desenvolvedores "**black
+belt**\ " criada para providenciar um serviço de apoio "nível 2" para aquelas
+horas do aperto. Também falamos sobre a comunidade **Python** do Brasil, `Small
+Acts`_, apresentações pelos Estados Unidos, `Revista INPUT`_ (quem já teve um
+computador **TK85** ou **ZX Spectrum** sabe do que estou falando), e mais um
+monte coisas bacanas!
 
 Escute Agora
 ------------
@@ -53,8 +51,8 @@ Contato
 -  Facebook: http://www.facebook.com/henriquebastos
 -  Flickr: http://www.flickr.com/photos/henriquebastos
 -  Github: https://github.com/henriquebastos
--  `Welcome to the Django <http://welcometothedjango.com.br/>`__
--  `Dekode <http://dekode.com.br/>`__
+-  `Welcome to the Django`_
+-  `Dekode`_
 
 Resumo
 ------
@@ -74,73 +72,73 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Metallica <http://www.last.fm/search?q=Metallica>`__
--  **Música:** `Megadeath <http://www.last.fm/search?q=Megadeath>`__
--  **Música:** `Rise Against the Machine <http://www.last.fm/search?q=Rise+Against+the+Machine>`__
--  **Filmes:** `The Matrix <http://www.imdb.com/find?s=all&q=The+Matrix>`__
--  **Filmes:** `O Poderoso Chefão <http://www.imdb.com/find?s=all&q=O+Poderoso+Chefão>`__
--  **Filmes:** `De Volta para o Futuro <http://www.imdb.com/find?s=all&q=De+Volta+para+o+Futuro>`__
--  **Filmes:** `Star Gate <http://www.imdb.com/find?s=all&q=Star+Gate>`__
--  **Livros:** `Revista INPUT <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Revista+INPUT>`__ (`PDFs <http://www.datacassete.com.br/>`__ de todas)
--  **Livros:** `Presentation Zen <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Presentation+Zen>`__
--  **Livros:** `Code <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Code>`__
--  **Livros:** `O Conselheiro <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=O+Conselheiro>`__
--  **Livros:** `A Origem do Capitalism <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=A+Origem+do+Capitalism>`__
+-  **Música:** `Metallica`_
+-  **Música:** `Megadeath`_
+-  **Música:** `Rise Against the Machine`_
+-  **Filmes:** `The Matrix`_
+-  **Filmes:** `O Poderoso Chefão`_
+-  **Filmes:** `De Volta para o Futuro`_
+-  **Filmes:** `Star Gate`_
+-  **Livros:** `Revista INPUT (Amazon)`_ (`PDFs`_ de todas)
+-  **Livros:** `Presentation Zen`_
+-  **Livros:** `Code`_
+-  **Livros:** `O Conselheiro`_
+-  **Livros:** `A Origem do Capitalism`_
 
 Links
 -----
--  `Guns and Roses <https://duckduckgo.com/?q=Guns+and+Roses>`__
--  `Django <https://duckduckgo.com/?q=Django>`__
--  `Coding Dojo <https://duckduckgo.com/?q=Coding+Dojo>`__
--  `Python <https://duckduckgo.com/?q=Python>`__
--  `Coding Sprint <https://duckduckgo.com/?q=Coding+Sprint>`__
--  `Desenvolvimento Ágil <https://duckduckgo.com/?q=Desenvolvimento+Ágil>`__
--  `Python Brasil <https://duckduckgo.com/?q=Python+Brasil>`__
--  `Heroku <https://duckduckgo.com/?q=Heroku>`__
--  `Amazon EC2 <https://duckduckgo.com/?q=Amazon+EC2>`__
--  `Git <https://duckduckgo.com/?q=Git>`__
--  `Platform as a Service (PaaS) <https://duckduckgo.com/?q=Platform+as+a+Service+(PaaS)>`__
--  `Controle de Versão Distribuído <https://duckduckgo.com/?q=Controle+de+Versão+Distribuído>`__
--  `Github <https://duckduckgo.com/?q=Github>`__
--  `Adobe Connect <https://duckduckgo.com/?q=Adobe+Connect>`__
--  `WebEx <https://duckduckgo.com/?q=WebEx>`__
--  `Genial <https://duckduckgo.com/?q=Genial>`__
--  `Go To PC <https://duckduckgo.com/?q=Go+To+PC>`__
--  `Adobe Flash <https://duckduckgo.com/?q=Adobe+Flash>`__
--  `Dekode <https://duckduckgo.com/?q=Dekode>`__
--  `Gabriel Falcão <https://duckduckgo.com/?q=Gabriel+Falcão>`__
--  `Guake <https://duckduckgo.com/?q=Guake>`__
--  `Bernardo Fontes <https://duckduckgo.com/?q=Bernardo+Fontes>`__
--  `Tiago Garcia <https://duckduckgo.com/?q=Tiago+Garcia>`__
--  `MetaPix <https://duckduckgo.com/?q=MetaPix>`__
--  `PhotoShop <https://duckduckgo.com/?q=PhotoShop>`__
--  `Illustrator <https://duckduckgo.com/?q=Illustrator>`__
--  `Code Review <https://duckduckgo.com/?q=Code+Review>`__
--  `PyCon 2010 <https://duckduckgo.com/?q=PyCon+2010>`__
--  `FISL 2009 <https://duckduckgo.com/?q=FISL+2009>`__
--  `Porto Alegre <https://duckduckgo.com/?q=Porto+Alegre>`__
--  `Jacob Kaplan-Moss <https://duckduckgo.com/?q=Jacob+Kaplan-Moss>`__
--  `Guilherme Chapievsky <https://duckduckgo.com/?q=Guilherme+Chapievsky>`__
--  `Google <https://duckduckgo.com/?q=Google>`__
--  `Ryan Ozimek <https://duckduckgo.com/?q=Ryan+Ozimek>`__
--  `Joomla <https://duckduckgo.com/?q=Joomla>`__
--  `PHP Rio <https://duckduckgo.com/?q=PHP+Rio>`__
--  `Jeff Patton <https://duckduckgo.com/?q=Jeff+Patton>`__
--  `Globo.com <https://duckduckgo.com/?q=Globo.com>`__
--  `Vimeo <https://duckduckgo.com/?q=Vimeo>`__ (vídeos `1 <http://devinrio.com.br/2009>`__ `2 <http://devinrio.com.br/>`__ `3 <http://vimeo.com/channels/devinrio>`__ `4 <http://www.flickr.com/groups/devinrio/>`__)
--  `Java <https://duckduckgo.com/?q=Java>`__
--  `Small Acts <https://duckduckgo.com/?q=Small+Acts>`__
--  `Caike <https://duckduckgo.com/?q=Caike>`__ Souza
--  `HoverBoard <https://duckduckgo.com/?q=HoverBoard>`__
--  `.NET <https://duckduckgo.com/?q=.NET>`__
--  `C# <https://duckduckgo.com/?q=C#>`__
--  `VB.Net <https://duckduckgo.com/?q=VB.Net>`__
--  `DataK7 <https://duckduckgo.com/?q=DataK7>`__
--  `Garr Reynolds <https://duckduckgo.com/?q=Garr+Reynolds>`__
--  `Charles Petzold <https://duckduckgo.com/?q=Charles+Petzold>`__
--  `Código Morse <https://duckduckgo.com/?q=Código+Morse>`__
--  `Ellen Wood <https://duckduckgo.com/?q=Ellen+Wood>`__
--  `Hugo Doria <https://duckduckgo.com/?q=Hugo+Doria>`__
+-  `Guns and Roses`_
+-  `Django`_
+-  `Coding Dojo`_
+-  `Python`_
+-  `Coding Sprint`_
+-  `Desenvolvimento Ágil`_
+-  `Python Brasil`_
+-  `Heroku`_
+-  `Amazon EC2`_
+-  `Git`_
+-  `Platform as a Service (PaaS)`_
+-  `Controle de Versão Distribuído`_
+-  `Github`_
+-  `Adobe Connect`_
+-  `WebEx`_
+-  `Genial`_
+-  `Go To PC`_
+-  `Adobe Flash`_
+-  `Dekode (DuckDuckGo)`_
+-  `Gabriel Falcão`_
+-  `Guake`_
+-  `Bernardo Fontes`_
+-  `Tiago Garcia`_
+-  `MetaPix`_
+-  `PhotoShop`_
+-  `Illustrator`_
+-  `Code Review`_
+-  `PyCon 2010`_
+-  `FISL 2009`_
+-  `Porto Alegre`_
+-  `Jacob Kaplan-Moss`_
+-  `Guilherme Chapievsky`_
+-  `Google`_
+-  `Ryan Ozimek`_
+-  `Joomla`_
+-  `PHP Rio`_
+-  `Jeff Patton`_
+-  `Globo.com`_
+-  `Vimeo`_ (vídeos `1`_ `2`_ `3`_ `4`_)
+-  `Java`_
+-  `Small Acts (DuckDuckGo)`_
+-  `Caike`_ Souza
+-  `HoverBoard`_
+-  `.NET`_
+-  `C#`_
+-  `VB.Net`_
+-  `DataK7`_
+-  `Garr Reynolds`_
+-  `Charles Petzold`_
+-  `Código Morse`_
+-  `Ellen Wood`_
+-  `Hugo Doria`_
 
 .. class:: panel-body bg-info
 
@@ -149,3 +147,76 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _Small Acts: http://smallactsmanifesto.org/
+.. _Revista INPUT: http://www.datacassete.com.br/
+.. _Welcome to the Django: http://welcometothedjango.com.br/
+.. _Dekode: http://dekode.com.br/
+.. _Metallica: http://www.last.fm/search?q=Metallica
+.. _Megadeath: http://www.last.fm/search?q=Megadeath
+.. _Rise Against the Machine: http://www.last.fm/search?q=Rise+Against+the+Machine
+.. _The Matrix: http://www.imdb.com/find?s=all&q=The+Matrix
+.. _O Poderoso Chefão: http://www.imdb.com/find?s=all&q=O+Poderoso+Chefão
+.. _De Volta para o Futuro: http://www.imdb.com/find?s=all&q=De+Volta+para+o+Futuro
+.. _Star Gate: http://www.imdb.com/find?s=all&q=Star+Gate
+.. _Revista INPUT (Amazon): http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Revista+INPUT
+.. _Presentation Zen: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Presentation+Zen
+.. _Code: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Code
+.. _O Conselheiro: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=O+Conselheiro
+.. _A Origem do Capitalism: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=A+Origem+do+Capitalism
+.. _Guns and Roses: https://duckduckgo.com/?q=Guns+and+Roses
+.. _Django: https://duckduckgo.com/?q=Django
+.. _Coding Dojo: https://duckduckgo.com/?q=Coding+Dojo
+.. _Python: https://duckduckgo.com/?q=Python
+.. _Coding Sprint: https://duckduckgo.com/?q=Coding+Sprint
+.. _Desenvolvimento Ágil: https://duckduckgo.com/?q=Desenvolvimento+Ágil
+.. _Python Brasil: https://duckduckgo.com/?q=Python+Brasil
+.. _Heroku: https://duckduckgo.com/?q=Heroku
+.. _Amazon EC2: https://duckduckgo.com/?q=Amazon+EC2
+.. _Git: https://duckduckgo.com/?q=Git
+.. _Platform as a Service (PaaS): https://duckduckgo.com/?q=Platform+as+a+Service+(PaaS)
+.. _Controle de Versão Distribuído: https://duckduckgo.com/?q=Controle+de+Versão+Distribuído
+.. _Github: https://duckduckgo.com/?q=Github
+.. _Adobe Connect: https://duckduckgo.com/?q=Adobe+Connect
+.. _WebEx: https://duckduckgo.com/?q=WebEx
+.. _Genial: https://duckduckgo.com/?q=Genial
+.. _Go To PC: https://duckduckgo.com/?q=Go+To+PC
+.. _Adobe Flash: https://duckduckgo.com/?q=Adobe+Flash
+.. _Dekode (DuckDuckGo): https://duckduckgo.com/?q=Dekode
+.. _Gabriel Falcão: https://duckduckgo.com/?q=Gabriel+Falcão
+.. _Guake: https://duckduckgo.com/?q=Guake
+.. _Bernardo Fontes: https://duckduckgo.com/?q=Bernardo+Fontes
+.. _Tiago Garcia: https://duckduckgo.com/?q=Tiago+Garcia
+.. _MetaPix: https://duckduckgo.com/?q=MetaPix
+.. _PhotoShop: https://duckduckgo.com/?q=PhotoShop
+.. _Illustrator: https://duckduckgo.com/?q=Illustrator
+.. _Code Review: https://duckduckgo.com/?q=Code+Review
+.. _PyCon 2010: https://duckduckgo.com/?q=PyCon+2010
+.. _FISL 2009: https://duckduckgo.com/?q=FISL+2009
+.. _Porto Alegre: https://duckduckgo.com/?q=Porto+Alegre
+.. _Jacob Kaplan-Moss: https://duckduckgo.com/?q=Jacob+Kaplan-Moss
+.. _Guilherme Chapievsky: https://duckduckgo.com/?q=Guilherme+Chapievsky
+.. _Google: https://duckduckgo.com/?q=Google
+.. _Ryan Ozimek: https://duckduckgo.com/?q=Ryan+Ozimek
+.. _Joomla: https://duckduckgo.com/?q=Joomla
+.. _PHP Rio: https://duckduckgo.com/?q=PHP+Rio
+.. _Jeff Patton: https://duckduckgo.com/?q=Jeff+Patton
+.. _Globo.com: https://duckduckgo.com/?q=Globo.com
+.. _Vimeo: https://duckduckgo.com/?q=Vimeo
+.. _Java: https://duckduckgo.com/?q=Java
+.. _Small Acts (DuckDuckGo): https://duckduckgo.com/?q=Small+Acts
+.. _Caike: https://duckduckgo.com/?q=Caike
+.. _HoverBoard: https://duckduckgo.com/?q=HoverBoard
+.. _.NET: https://duckduckgo.com/?q=.NET
+.. _C#: https://duckduckgo.com/?q=C#
+.. _VB.Net: https://duckduckgo.com/?q=VB.Net
+.. _DataK7: https://duckduckgo.com/?q=DataK7
+.. _Garr Reynolds: https://duckduckgo.com/?q=Garr+Reynolds
+.. _Charles Petzold: https://duckduckgo.com/?q=Charles+Petzold
+.. _Código Morse: https://duckduckgo.com/?q=Código+Morse
+.. _Ellen Wood: https://duckduckgo.com/?q=Ellen+Wood
+.. _Hugo Doria: https://duckduckgo.com/?q=Hugo+Doria
+.. _PDFs: http://www.datacassete.com.br/
+.. _1: http://devinrio.com.br/2009
+.. _2: http://devinrio.com.br/
+.. _3: http://vimeo.com/channels/devinrio
+.. _4: http://www.flickr.com/groups/devinrio/

--- a/content/episodes/034-julio-monteiro-jobscore.rst
+++ b/content/episodes/034-julio-monteiro-jobscore.rst
@@ -62,64 +62,64 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Daft Punk <http://www.last.fm/search?q=Daft+Punk>`__
--  **Música:** `Four Tet <http://www.last.fm/search?q=Four+Tet>`__
--  **Música:** `Justice <http://www.last.fm/search?q=Justice>`__
--  **Música:** `Kraftwerk <http://www.last.fm/search?q=Kraftwerk>`__
--  **Música:** `Pat Metheny Group <http://www.last.fm/search?q=Pat+Metheny+Group>`__
--  **Música:** `Royksopp <http://www.last.fm/search?q=Royksopp>`__
--  **Música:** `Penguin Cafe Orchestra <http://www.last.fm/search?q=Penguin+Cafe+Orchestra>`__
--  **Música:** `Gotan Project <http://www.last.fm/search?q=Gotan+Project>`__
--  **Música:** `Tanghetto <http://www.last.fm/search?q=Tanghetto>`__
--  **Podcast:** `Grok Podcast <http://grokpodcast.com/>`__
--  **Podcast:** `NerdCast <http://jovemnerd.ig.com.br/categoria/nerdcast/>`__
--  **Podcast:** `Escriba Café <http://www.escribacafe.com/>`__
--  **Filmes:** `Howl's Moving Castle <http://www.imdb.com/find?s=all&q=Howl's+Moving+Castle>`__
--  **Filmes:** `Game of Thrones <http://www.imdb.com/find?s=all&q=Game+of+Thrones>`__
--  **Filmes:** `The Big Bang Theory <http://www.imdb.com/find?s=all&q=The+Big+Bang+Theory>`__
--  **Filmes:** `The IT Crowd <http://www.imdb.com/find?s=all&q=The+IT+Crowd>`__
--  **Filmes:** `Walking Dead <http://www.imdb.com/find?s=all&q=Walking+Dead>`__
--  **Livros:** `The Tipping Poing <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=The+Tipping+Poing>`__
--  **Livros:** `Blink <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Blink>`__
--  **Livros:** `Outliers <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Outliers>`__
--  **Livros:** `Drive <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Drive>`__
+-  **Música:** `Daft Punk`_
+-  **Música:** `Four Tet`_
+-  **Música:** `Justice`_
+-  **Música:** `Kraftwerk`_
+-  **Música:** `Pat Metheny Group`_
+-  **Música:** `Royksopp`_
+-  **Música:** `Penguin Cafe Orchestra`_
+-  **Música:** `Gotan Project`_
+-  **Música:** `Tanghetto`_
+-  **Podcast:** `Grok Podcast`_
+-  **Podcast:** `NerdCast`_
+-  **Podcast:** `Escriba Café`_
+-  **Filmes:** `Howl's Moving Castle`_
+-  **Filmes:** `Game of Thrones`_
+-  **Filmes:** `The Big Bang Theory`_
+-  **Filmes:** `The IT Crowd`_
+-  **Filmes:** `Walking Dead`_
+-  **Livros:** `The Tipping Poing`_
+-  **Livros:** `Blink`_
+-  **Livros:** `Outliers`_
+-  **Livros:** `Drive`_
 
 Links
 -----
--  `JobScore <https://duckduckgo.com/?q=JobScore>`__
--  `Ubuntu Brasil <https://duckduckgo.com/?q=Ubuntu+Brasil>`__
--  `HTML <https://duckduckgo.com/?q=HTML>`__
--  `Cadê? <https://duckduckgo.com/?q=Cadê?>`__
--  `Linux <https://duckduckgo.com/?q=Linux>`__
--  `Windows <https://duckduckgo.com/?q=Windows>`__
--  `Javascript <https://duckduckgo.com/?q=Javascript>`__
--  `Programação Ruby <https://duckduckgo.com/?q=Programação+Ruby>`__
--  `Programação Python <https://duckduckgo.com/?q=Programação+Python>`__
--  `Professor Marco André <https://duckduckgo.com/?q=Professor+Marco+André>`__
--  `Programação PHP <https://duckduckgo.com/?q=Programação+PHP>`__
--  `Django <https://duckduckgo.com/?q=Django>`__
--  `TurboGears <https://duckduckgo.com/?q=TurboGears>`__
--  `Ruby on Rails <https://duckduckgo.com/?q=Ruby+on+Rails>`__
--  `FISL 2004 <https://duckduckgo.com/?q=FISL+2004>`__
--  `Symphony <https://duckduckgo.com/?q=Symphony>`__
--  `Mato Grosso <https://duckduckgo.com/?q=Mato+Grosso>`__
--  `Rails BR <https://duckduckgo.com/?q=Rails+BR>`__
--  `Companhia Startup <https://duckduckgo.com/?q=Companhia+Startup>`__
--  `Job Board <https://duckduckgo.com/?q=Job+Board>`__
--  `QA <https://duckduckgo.com/?q=QA>`__
--  `Continuous Integration <https://duckduckgo.com/?q=Continuous+Integration>`__
--  `Heroku <https://duckduckgo.com/?q=Heroku>`__
--  `Henrique Bastos <https://duckduckgo.com/?q=Henrique+Bastos>`__
--  `Pedro Belo <https://duckduckgo.com/?q=Pedro+Belo>`__
--  `Fábio Kung <https://duckduckgo.com/?q=Fábio+Kung>`__
--  `Meetups <https://duckduckgo.com/?q=Meetups>`__
--  `Github Drinkup <https://duckduckgo.com/?q=Github+Drinkup>`__
--  `Github <https://duckduckgo.com/?q=Github>`__
--  `MongoDB <https://duckduckgo.com/?q=MongoDB>`__
--  `Instapaper <http://www.instapaper.com/>`__
--  `FlipBoard <http://flipboard.com/>`__
--  `HackerNews <http://news.ycombinator.com/>`__
--  `HackerNews Monthly <http://hackermonthly.com/>`__
+-  `JobScore`_
+-  `Ubuntu Brasil`_
+-  `HTML`_
+-  `Cadê?`_
+-  `Linux`_
+-  `Windows`_
+-  `Javascript`_
+-  `Programação Ruby`_
+-  `Programação Python`_
+-  `Professor Marco André`_
+-  `Programação PHP`_
+-  `Django`_
+-  `TurboGears`_
+-  `Ruby on Rails`_
+-  `FISL 2004`_
+-  `Symphony`_
+-  `Mato Grosso`_
+-  `Rails BR`_
+-  `Companhia Startup`_
+-  `Job Board`_
+-  `QA`_
+-  `Continuous Integration`_
+-  `Heroku`_
+-  `Henrique Bastos`_
+-  `Pedro Belo`_
+-  `Fábio Kung`_
+-  `Meetups`_
+-  `Github Drinkup`_
+-  `Github`_
+-  `MongoDB`_
+-  `Instapaper`_
+-  `FlipBoard`_
+-  `HackerNews`_
+-  `HackerNews Monthly`_
 
 .. class:: panel-body bg-info
 
@@ -128,3 +128,58 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _Daft Punk: http://www.last.fm/search?q=Daft+Punk
+.. _Four Tet: http://www.last.fm/search?q=Four+Tet
+.. _Justice: http://www.last.fm/search?q=Justice
+.. _Kraftwerk: http://www.last.fm/search?q=Kraftwerk
+.. _Pat Metheny Group: http://www.last.fm/search?q=Pat+Metheny+Group
+.. _Royksopp: http://www.last.fm/search?q=Royksopp
+.. _Penguin Cafe Orchestra: http://www.last.fm/search?q=Penguin+Cafe+Orchestra
+.. _Gotan Project: http://www.last.fm/search?q=Gotan+Project
+.. _Tanghetto: http://www.last.fm/search?q=Tanghetto
+.. _Grok Podcast: http://grokpodcast.com/
+.. _NerdCast: http://jovemnerd.ig.com.br/categoria/nerdcast/
+.. _Escriba Café: http://www.escribacafe.com/
+.. _Howl's Moving Castle: http://www.imdb.com/find?s=all&q=Howl's+Moving+Castle
+.. _Game of Thrones: http://www.imdb.com/find?s=all&q=Game+of+Thrones
+.. _The Big Bang Theory: http://www.imdb.com/find?s=all&q=The+Big+Bang+Theory
+.. _The IT Crowd: http://www.imdb.com/find?s=all&q=The+IT+Crowd
+.. _Walking Dead: http://www.imdb.com/find?s=all&q=Walking+Dead
+.. _The Tipping Poing: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=The+Tipping+Poing
+.. _Blink: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Blink
+.. _Outliers: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Outliers
+.. _Drive: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Drive
+.. _JobScore: https://duckduckgo.com/?q=JobScore
+.. _Ubuntu Brasil: https://duckduckgo.com/?q=Ubuntu+Brasil
+.. _HTML: https://duckduckgo.com/?q=HTML
+.. _Cadê?: https://duckduckgo.com/?q=Cadê?
+.. _Linux: https://duckduckgo.com/?q=Linux
+.. _Windows: https://duckduckgo.com/?q=Windows
+.. _Javascript: https://duckduckgo.com/?q=Javascript
+.. _Programação Ruby: https://duckduckgo.com/?q=Programação+Ruby
+.. _Programação Python: https://duckduckgo.com/?q=Programação+Python
+.. _Professor Marco André: https://duckduckgo.com/?q=Professor+Marco+André
+.. _Programação PHP: https://duckduckgo.com/?q=Programação+PHP
+.. _Django: https://duckduckgo.com/?q=Django
+.. _TurboGears: https://duckduckgo.com/?q=TurboGears
+.. _Ruby on Rails: https://duckduckgo.com/?q=Ruby+on+Rails
+.. _FISL 2004: https://duckduckgo.com/?q=FISL+2004
+.. _Symphony: https://duckduckgo.com/?q=Symphony
+.. _Mato Grosso: https://duckduckgo.com/?q=Mato+Grosso
+.. _Rails BR: https://duckduckgo.com/?q=Rails+BR
+.. _Companhia Startup: https://duckduckgo.com/?q=Companhia+Startup
+.. _Job Board: https://duckduckgo.com/?q=Job+Board
+.. _QA: https://duckduckgo.com/?q=QA
+.. _Continuous Integration: https://duckduckgo.com/?q=Continuous+Integration
+.. _Heroku: https://duckduckgo.com/?q=Heroku
+.. _Henrique Bastos: https://duckduckgo.com/?q=Henrique+Bastos
+.. _Pedro Belo: https://duckduckgo.com/?q=Pedro+Belo
+.. _Fábio Kung: https://duckduckgo.com/?q=Fábio+Kung
+.. _Meetups: https://duckduckgo.com/?q=Meetups
+.. _Github Drinkup: https://duckduckgo.com/?q=Github+Drinkup
+.. _Github: https://duckduckgo.com/?q=Github
+.. _MongoDB: https://duckduckgo.com/?q=MongoDB
+.. _Instapaper: http://www.instapaper.com/
+.. _FlipBoard: http://flipboard.com/
+.. _HackerNews: http://news.ycombinator.com/
+.. _HackerNews Monthly: http://hackermonthly.com/

--- a/content/episodes/035-fabio-kung-e-pedro-belo-heroku.rst
+++ b/content/episodes/035-fabio-kung-e-pedro-belo-heroku.rst
@@ -13,15 +13,11 @@ Fábio Kung e Pedro Belo: Heroku
 
 Olá pessoal e sejam bem-vindos à mais um episódio, desta vez com dois
 convidados: **Fábio Kung** e **Pedro Belo**, que atualmente trabalham na
-companhia Californiana **Heroku**! Se você escutou os dois últimos
-episódios, você deve se lembrar que eu mencionei sobre esta companhia
-com o `Henrique
-Bastos <http://www.castalio.info/henrique-bastos-welcome-to-the-django/>`__
-e `Júlio
-Monteiro <http://www.castalio.info/julio-monteiro-jobscore/>`__, e como
-que eu tenho usado os serviços que eles oferecem para hospedar e rodar
-alguns dos meus projetos. Então quando o Júlio se ofereceu para me
-apresentar ao pessoal da Heroku eu aceitei na mesma hora!
+companhia Californiana **Heroku**! Se você escutou os dois últimos episódios,
+você deve se lembrar que eu mencionei sobre esta companhia com o `Henrique
+Bastos`_ e `Júlio Monteiro`_, e como que eu tenho usado os serviços que eles
+oferecem para hospedar e rodar alguns dos meus projetos. Então quando o Júlio
+se ofereceu para me apresentar ao pessoal da Heroku eu aceitei na mesma hora!
 
 Nosso bate-papo foi super divertido, e mesmo com os **três fusos de
 horário diferentes** (o Fábio na **California**, Pedro no **Texas** e eu
@@ -77,73 +73,73 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Radio Head <http://www.last.fm/search?q=Radio+Head>`__
--  **Música:** `PJ Harvey <http://www.last.fm/search?q=PJ+Harvey>`__
--  **Música:** `The Black Keys <http://www.last.fm/search?q=The+Black+Keys>`__
--  **Música:** `Queens of the Stone Age <http://www.last.fm/search?q=Queens+of+the+Stone+Age>`__
--  **Música:** `The Atomic BitchWax <http://www.last.fm/search?q=The+Atomic+BitchWax>`__
--  **Música:** `Cold Play <http://www.last.fm/search?q=Cold+Play>`__
--  **Filmes:** `The Girl with the Dragon Tatoo <http://www.imdb.com/find?s=all&q=The+Girl+with+the+Dragon+Tatoo>`__
--  **Filmes:** `O Senhor dos Anéis <http://www.imdb.com/find?s=all&q=O+Senhor+dos+Anéis>`__
--  **Filmes:** `Fringe <http://www.imdb.com/find?s=all&q=Fringe>`__
--  **Filmes:** `Vampire Diaries <http://www.imdb.com/find?s=all&q=Vampire+Diaries>`__
--  **Filmes:** `Supernatural <http://www.imdb.com/find?s=all&q=Supernatural>`__
--  **Filmes:** `The Big Bang Theory <http://www.imdb.com/find?s=all&q=The+Big+Bang+Theory>`__
--  **Filmes:** `Game of Thrones <http://www.imdb.com/find?s=all&q=Game+of+Thrones>`__
--  **Filmes:** `Adaptation <http://www.imdb.com/find?s=all&q=Adaptation>`__
--  **Filmes:** `Being John Malkovich <http://www.imdb.com/find?s=all&q=Being+John+Malkovich>`__
--  **Livros:** `Clube da Luta <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Clube+da+Luta>`__
--  **Livros:** `Survivor: A Novel <http://www.amazon.com/Survivor-A-Novel-Chuck-Palahniuk/dp/0385498721?tag=duckduckgo-d-20>`__
--  **Livros:** `Effective C++ <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Effective+C++>`__
--  **Livros:** `Wikipedia <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Wikipedia>`__
--  **Livros:** `Hacker News <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Hacker+News>`__
+-  **Música:** `Radio Head`_
+-  **Música:** `PJ Harvey`_
+-  **Música:** `The Black Keys`_
+-  **Música:** `Queens of the Stone Age`_
+-  **Música:** `The Atomic BitchWax`_
+-  **Música:** `Cold Play`_
+-  **Filmes:** `The Girl with the Dragon Tatoo`_
+-  **Filmes:** `O Senhor dos Anéis`_
+-  **Filmes:** `Fringe`_
+-  **Filmes:** `Vampire Diaries`_
+-  **Filmes:** `Supernatural`_
+-  **Filmes:** `The Big Bang Theory`_
+-  **Filmes:** `Game of Thrones`_
+-  **Filmes:** `Adaptation`_
+-  **Filmes:** `Being John Malkovich`_
+-  **Livros:** `Clube da Luta`_
+-  **Livros:** `Survivor\: A Novel`_
+-  **Livros:** `Effective C++`_
+-  **Livros:** `Wikipedia`_
+-  **Livros:** `Hacker News`_
 
 Links
 -----
--  `Heroku <https://duckduckgo.com/?q=Heroku>`__
--  `Platform as a Service <https://duckduckgo.com/?q=Platform+as+a+Service>`__
--  `Júlio Monteiro <https://duckduckgo.com/?q=Júlio+Monteiro>`__
--  `Amazon Cloud <https://duckduckgo.com/?q=Amazon+Cloud>`__
--  `Dreamhost <https://duckduckgo.com/?q=Dreamhost>`__
--  `Framework Django <https://duckduckgo.com/?q=Framework+Django>`__
--  `nginx <https://duckduckgo.com/?q=nginx>`__
--  `Certificado SSL <https://duckduckgo.com/?q=Certificado+SSL>`__
--  `PHP <https://duckduckgo.com/?q=PHP>`__
--  `Python <https://duckduckgo.com/?q=Python>`__
--  `Ruby <https://duckduckgo.com/?q=Ruby>`__
--  `Emulador de NES <https://duckduckgo.com/?q=Emulador+de+NES>`__
--  `WhiteSpace <https://duckduckgo.com/?q=WhiteSpace>`__
--  `BrainFuck <https://duckduckgo.com/?q=BrainFuck>`__
--  `Ruby on Rails <https://duckduckgo.com/?q=Ruby+on+Rails>`__
--  `Node.js <https://duckduckgo.com/?q=Node.js>`__
--  `Kenneth Reitz <https://duckduckgo.com/?q=Kenneth+Reitz>`__
--  `Python Requests <https://duckduckgo.com/?q=Python+Requests>`__
--  `Jabberd <https://duckduckgo.com/?q=Jabberd>`__
--  `Erlang <https://duckduckgo.com/?q=Erlang>`__
--  `rPath <https://duckduckgo.com/?q=rPath>`__
--  `tempwatch <https://duckduckgo.com/?q=tempwatch>`__
--  `man pages <https://duckduckgo.com/?q=man+pages>`__
--  `Red Hat <https://duckduckgo.com/?q=Red+Hat>`__
--  `Mozilla <https://duckduckgo.com/?q=Mozilla>`__
--  `Github <https://duckduckgo.com/?q=Github>`__
--  `Vale do Silício <https://duckduckgo.com/?q=Vale+do+Silício>`__
--  `Bruce Eckel <https://duckduckgo.com/?q=Bruce+Eckel>`__
--  `Google <https://duckduckgo.com/?q=Google>`__
--  `Yukihiro Matsumoto <https://duckduckgo.com/?q=Yukihiro+Matsumoto>`__
--  `Google AppEngine <https://duckduckgo.com/?q=Google+AppEngine>`__
--  `Cloud Foundry <https://duckduckgo.com/?q=Cloud+Foundry>`__
--  `Windows Azzure <https://duckduckgo.com/?q=Windows+Azzure>`__
--  `DotCloud <https://duckduckgo.com/?q=DotCloud>`__
--  `Java <https://duckduckgo.com/?q=Java>`__
--  `Spring MVC <https://duckduckgo.com/?q=Spring+MVC>`__
--  `Hybernate <https://duckduckgo.com/?q=Hybernate>`__
--  `Git <https://duckduckgo.com/?q=Git>`__
--  `DrinkUp <https://duckduckgo.com/?q=DrinkUp>`__
--  `MeetUp <https://duckduckgo.com/?q=MeetUp>`__
--  `RailsConf <https://duckduckgo.com/?q=RailsConf>`__
--  `JSON <https://duckduckgo.com/?q=JSON>`__
--  `ActiveRecord <https://duckduckgo.com/?q=ActiveRecord>`__
--  `Kindle <https://duckduckgo.com/?q=Kindle>`__
+-  `Heroku`_
+-  `Platform as a Service`_
+-  `Júlio Monteiro (DuckDuckGo)`_
+-  `Amazon Cloud`_
+-  `Dreamhost`_
+-  `Framework Django`_
+-  `nginx`_
+-  `Certificado SSL`_
+-  `PHP`_
+-  `Python`_
+-  `Ruby`_
+-  `Emulador de NES`_
+-  `WhiteSpace`_
+-  `BrainFuck`_
+-  `Ruby on Rails`_
+-  `Node.js`_
+-  `Kenneth Reitz`_
+-  `Python Requests`_
+-  `Jabberd`_
+-  `Erlang`_
+-  `rPath`_
+-  `tempwatch`_
+-  `man pages`_
+-  `Red Hat`_
+-  `Mozilla`_
+-  `Github`_
+-  `Vale do Silício`_
+-  `Bruce Eckel`_
+-  `Google`_
+-  `Yukihiro Matsumoto`_
+-  `Google AppEngine`_
+-  `Cloud Foundry`_
+-  `Windows Azzure`_
+-  `DotCloud`_
+-  `Java`_
+-  `Spring MVC`_
+-  `Hybernate`_
+-  `Git`_
+-  `DrinkUp`_
+-  `MeetUp`_
+-  `RailsConf`_
+-  `JSON`_
+-  `ActiveRecord`_
+-  `Kindle`_
 
 .. class:: panel-body bg-info
 
@@ -152,3 +148,69 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _Henrique Bastos: http://www.castalio.info/henrique-bastos-welcome-to-the-django/
+.. _Júlio Monteiro: http://www.castalio.info/julio-monteiro-jobscore/
+.. _Radio Head: http://www.last.fm/search?q=Radio+Head
+.. _PJ Harvey: http://www.last.fm/search?q=PJ+Harvey
+.. _The Black Keys: http://www.last.fm/search?q=The+Black+Keys
+.. _Queens of the Stone Age: http://www.last.fm/search?q=Queens+of+the+Stone+Age
+.. _The Atomic BitchWax: http://www.last.fm/search?q=The+Atomic+BitchWax
+.. _Cold Play: http://www.last.fm/search?q=Cold+Play
+.. _The Girl with the Dragon Tatoo: http://www.imdb.com/find?s=all&q=The+Girl+with+the+Dragon+Tatoo
+.. _O Senhor dos Anéis: http://www.imdb.com/find?s=all&q=O+Senhor+dos+Anéis
+.. _Fringe: http://www.imdb.com/find?s=all&q=Fringe
+.. _Vampire Diaries: http://www.imdb.com/find?s=all&q=Vampire+Diaries
+.. _Supernatural: http://www.imdb.com/find?s=all&q=Supernatural
+.. _The Big Bang Theory: http://www.imdb.com/find?s=all&q=The+Big+Bang+Theory
+.. _Game of Thrones: http://www.imdb.com/find?s=all&q=Game+of+Thrones
+.. _Adaptation: http://www.imdb.com/find?s=all&q=Adaptation
+.. _Being John Malkovich: http://www.imdb.com/find?s=all&q=Being+John+Malkovich
+.. _Clube da Luta: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Clube+da+Luta
+.. _Survivor\: A Novel: http://www.amazon.com/Survivor-A-Novel-Chuck-Palahniuk/dp/0385498721?tag=duckduckgo-d-20
+.. _Effective C++: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Effective+C++
+.. _Wikipedia: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Wikipedia
+.. _Hacker News: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Hacker+News
+.. _Heroku: https://duckduckgo.com/?q=Heroku
+.. _Platform as a Service: https://duckduckgo.com/?q=Platform+as+a+Service
+.. _Júlio Monteiro (DuckDuckGo): https://duckduckgo.com/?q=Júlio+Monteiro
+.. _Amazon Cloud: https://duckduckgo.com/?q=Amazon+Cloud
+.. _Dreamhost: https://duckduckgo.com/?q=Dreamhost
+.. _Framework Django: https://duckduckgo.com/?q=Framework+Django
+.. _nginx: https://duckduckgo.com/?q=nginx
+.. _Certificado SSL: https://duckduckgo.com/?q=Certificado+SSL
+.. _PHP: https://duckduckgo.com/?q=PHP
+.. _Python: https://duckduckgo.com/?q=Python
+.. _Ruby: https://duckduckgo.com/?q=Ruby
+.. _Emulador de NES: https://duckduckgo.com/?q=Emulador+de+NES
+.. _WhiteSpace: https://duckduckgo.com/?q=WhiteSpace
+.. _BrainFuck: https://duckduckgo.com/?q=BrainFuck
+.. _Ruby on Rails: https://duckduckgo.com/?q=Ruby+on+Rails
+.. _Node.js: https://duckduckgo.com/?q=Node.js
+.. _Kenneth Reitz: https://duckduckgo.com/?q=Kenneth+Reitz
+.. _Python Requests: https://duckduckgo.com/?q=Python+Requests
+.. _Jabberd: https://duckduckgo.com/?q=Jabberd
+.. _Erlang: https://duckduckgo.com/?q=Erlang
+.. _rPath: https://duckduckgo.com/?q=rPath
+.. _tempwatch: https://duckduckgo.com/?q=tempwatch
+.. _man pages: https://duckduckgo.com/?q=man+pages
+.. _Red Hat: https://duckduckgo.com/?q=Red+Hat
+.. _Mozilla: https://duckduckgo.com/?q=Mozilla
+.. _Github: https://duckduckgo.com/?q=Github
+.. _Vale do Silício: https://duckduckgo.com/?q=Vale+do+Silício
+.. _Bruce Eckel: https://duckduckgo.com/?q=Bruce+Eckel
+.. _Google: https://duckduckgo.com/?q=Google
+.. _Yukihiro Matsumoto: https://duckduckgo.com/?q=Yukihiro+Matsumoto
+.. _Google AppEngine: https://duckduckgo.com/?q=Google+AppEngine
+.. _Cloud Foundry: https://duckduckgo.com/?q=Cloud+Foundry
+.. _Windows Azzure: https://duckduckgo.com/?q=Windows+Azzure
+.. _DotCloud: https://duckduckgo.com/?q=DotCloud
+.. _Java: https://duckduckgo.com/?q=Java
+.. _Spring MVC: https://duckduckgo.com/?q=Spring+MVC
+.. _Hybernate: https://duckduckgo.com/?q=Hybernate
+.. _Git: https://duckduckgo.com/?q=Git
+.. _DrinkUp: https://duckduckgo.com/?q=DrinkUp
+.. _MeetUp: https://duckduckgo.com/?q=MeetUp
+.. _RailsConf: https://duckduckgo.com/?q=RailsConf
+.. _JSON: https://duckduckgo.com/?q=JSON
+.. _ActiveRecord: https://duckduckgo.com/?q=ActiveRecord
+.. _Kindle: https://duckduckgo.com/?q=Kindle

--- a/content/episodes/036-caike-souza-envy-labs.rst
+++ b/content/episodes/036-caike-souza-envy-labs.rst
@@ -12,16 +12,13 @@ Caike Souza: Envy Labs
 
    Caike Souza: Envy Labs
 
-Nem parece que já passaram duas semanas desde o último episódio, mas
-mais uma vez tive o prazer de entrevistar uma pessoa prá lá de
-interessante e divertida: o **Caike Souza**! Foi durante a minha
-entrevista com o `Henrique
-Bastos <http://www.castalio.info/henrique-bastos-welcome-to-the-django/>`__
-que eu fiquei sabendo sobre ele, mas foi somente esta semana que eu fui
-saber que ele trabalha na **Envy Labs** desde 2009 lá em **Orlando**, na
-**Flórida**. A companhia parece ser super bacana e está por trás de
-vários projetos bacanas, como o **Rails for Zombies**, **Code School** e
-**TryRuby.org**.
+Nem parece que já passaram duas semanas desde o último episódio, mas mais uma
+vez tive o prazer de entrevistar uma pessoa prá lá de interessante e divertida:
+o **Caike Souza**! Foi durante a minha entrevista com o `Henrique Bastos`_ que
+eu fiquei sabendo sobre ele, mas foi somente esta semana que eu fui saber que
+ele trabalha na **Envy Labs** desde 2009 lá em **Orlando**, na **Flórida**.
+A companhia parece ser super bacana e está por trás de vários projetos bacanas,
+como o **Rails for Zombies**, **Code School** e **TryRuby.org**.
 
 A primeira coisa que fica bem evidente sobre o Caike é que ele realmente
 curte muito o que faz, tem muito orgulho de onde trabalha, e é super
@@ -37,13 +34,11 @@ Twitter**!!!
 
 .. more
 
-Esta semana eu ainda pretendo conversar com ele sobre um **brinde** para
-vocês brincarem mais com o Code School, mas enquanto isso, vale a pena
-conferir o Rails for Zombies e baixar a `música da
-banda <https://www.facebook.com/heroeswillfall?sk=app_204974879526524>`__
-se você curte **Heavy Metal** (a música da entrada do episódio é da
-banda) ou quer conhecer um pouco mais sobre esta pessoa super
-interessante que é o Caike!
+Esta semana eu ainda pretendo conversar com ele sobre um **brinde** para vocês
+brincarem mais com o Code School, mas enquanto isso, vale a pena conferir
+o Rails for Zombies e baixar a `música da banda`_ se você curte **Heavy
+Metal** (a música da entrada do episódio é da banda) ou quer conhecer um pouco
+mais sobre esta pessoa super interessante que é o Caike!
 
 Escute Agora
 ------------
@@ -55,13 +50,12 @@ Contato
 -  **Blog:** http://caikesouza.com/blog/
 -  **Twitter**: https://twitter.com/#!/caike
 -  **Facebook**: https://www.facebook.com/caike.souza
--  **Banda**: `Heroes Will Fall <https://www.facebook.com/heroeswillfall>`__
+-  **Banda**: `Heroes Will Fall`_
 -  **Github**: https://github.com/caike
 -  **Envy Labs**: http://envylabs.com/
 -  **Code School**: http://www.codeschool.com/
 -  **Rails for Zombies**: http://www.railsforzombies.org/
--  **Palestra**: `Powerful
-   Interfaces <https://speakerdeck.com/u/caike/p/powerful-interfaces>`__
+-  **Palestra**: `Powerful Interfaces`_
 
 Resumo
 ------
@@ -81,24 +75,24 @@ Resumo
 
 Top 5
 -----
--  **Música:** `In Flames <http://www.last.fm/search?q=In+Flames>`__
--  **Música:** `Metallica <http://www.last.fm/search?q=Metallica>`__
--  **Música:** `Pantera <http://www.last.fm/search?q=Pantera>`__
--  **Música:** `Sepultura <http://www.last.fm/search?q=Sepultura>`__
--  **Música:** `Pendulum <http://www.last.fm/search?q=Pendulum>`__
--  **Música:** `Massive Attack <http://www.last.fm/search?q=Massive+Attack>`__
--  **Música:** `Postal Service <http://www.last.fm/search?q=Postal+Service>`__
--  **Música:** `Blink 182 <http://www.last.fm/search?q=Blink+182>`__
--  **Música:** `Gold Finger <http://www.last.fm/search?q=Gold+Finger>`__
--  **Música:** `Rancid <http://www.last.fm/search?q=Rancid>`__
--  **Filmes:** `Crash <http://www.imdb.com/find?s=all&q=Crash>`__
--  **Filmes:** `The Avengers <http://www.imdb.com/find?s=all&q=The+Avengers>`__
--  **Filmes:** `Breaking Bad <http://www.imdb.com/find?s=all&q=Breaking+Bad>`__
--  **Filmes:** `United States of Tara <http://www.imdb.com/find?s=all&q=United+States+of+Tara>`__
--  **Livros:** `Gunslinger <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Gunslinger>`__
--  **Livros:** `Ramones <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Ramones>`__
--  **Livros:** `Sepultura <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Sepultura>`__
--  **Livros:** `Mötley Crüe <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Mötley+Crüe>`__
+-  **Música:** `In Flames`_
+-  **Música:** `Metallica`_
+-  **Música:** `Pantera`_
+-  **Música:** `Sepultura`_
+-  **Música:** `Pendulum`_
+-  **Música:** `Massive Attack`_
+-  **Música:** `Postal Service`_
+-  **Música:** `Blink 182`_
+-  **Música:** `Gold Finger`_
+-  **Música:** `Rancid`_
+-  **Filmes:** `Crash`_
+-  **Filmes:** `The Avengers`_
+-  **Filmes:** `Breaking Bad`_
+-  **Filmes:** `United States of Tara`_
+-  **Livros:** `Gunslinger`_
+-  **Livros:** `Ramones`_
+-  **Livros:** `Sepultura (Amazon)`_
+-  **Livros:** `Mötley Crüe`_
 -  **Twitter**: https://twitter.com/#!/henriquebastos
 -  **Twitter**: https://twitter.com/#!/rafaelp
 -  **Twitter**: https://twitter.com/#!/ramonpage
@@ -113,46 +107,46 @@ Top 5
 
 Links
 -----
--  `Henrique Bastos <https://duckduckgo.com/?q=Henrique+Bastos>`__
--  `Envy Labs <https://duckduckgo.com/?q=Envy+Labs>`__
--  `Ruby on Rails <https://duckduckgo.com/?q=Ruby+on+Rails>`__
--  `Code School <https://duckduckgo.com/?q=Code+School>`__
--  `JQuery <https://duckduckgo.com/?q=JQuery>`__
--  `Ruby <https://duckduckgo.com/?q=Ruby>`__
--  `Javascript <https://duckduckgo.com/?q=Javascript>`__
--  `Coffee Script <https://duckduckgo.com/?q=Coffee+Script>`__
--  `HTML 5 <https://duckduckgo.com/?q=HTML+5>`__
--  `CSS <https://duckduckgo.com/?q=CSS>`__
--  `Responsive Web <https://duckduckgo.com/?q=Responsive+Web>`__
--  `Welcome to the Django <https://duckduckgo.com/?q=Welcome+to+the+Django>`__
--  `Banco de dados <https://duckduckgo.com/?q=Banco+de+dados>`__
--  `ActiveRecord <https://duckduckgo.com/?q=ActiveRecord>`__
--  `LivingSocial <https://duckduckgo.com/?q=LivingSocial>`__
--  `NASA <https://duckduckgo.com/?q=NASA>`__
--  `New York Times <https://duckduckgo.com/?q=New+York+Times>`__
--  `TopWorks <https://duckduckgo.com/?q=TopWorks>`__
--  `IBM <https://duckduckgo.com/?q=IBM>`__
--  `Rails for Zombies <https://duckduckgo.com/?q=Rails+for+Zombies>`__
--  `WordPress <https://duckduckgo.com/?q=WordPress>`__
--  `Node.js <https://duckduckgo.com/?q=Node.js>`__
--  `Backbone <https://duckduckgo.com/?q=Backbone>`__
--  `TryRuby.org <https://duckduckgo.com/?q=TryRuby.org>`__
--  `Code TV <https://duckduckgo.com/?q=Code+TV>`__
--  `Screencast <https://duckduckgo.com/?q=Screencast>`__
--  `RailsConf <https://duckduckgo.com/?q=RailsConf>`__
--  `Python <https://duckduckgo.com/?q=Python>`__
--  `Rails Testing for Zombies <https://duckduckgo.com/?q=Rails+Testing+for+Zombies>`__
--  `Interfaces <https://duckduckgo.com/?q=Interfaces>`__
--  `Tá Safo Conf 2012 <http://tasafo.org/conf2012/>`__
--  `Speaker Deck <https://duckduckgo.com/?q=Speaker+Deck>`__
--  `Capitão América <https://duckduckgo.com/?q=Capitão+América>`__
--  `Thor <https://duckduckgo.com/?q=Thor>`__
--  `Hulk <https://duckduckgo.com/?q=Hulk>`__
--  `Netflix <https://duckduckgo.com/?q=Netflix>`__
--  `Weeds <https://duckduckgo.com/?q=Weeds>`__
--  `HoraExtra <https://duckduckgo.com/?q=HoraExtra>`__
--  `Swarm Inteligence <https://duckduckgo.com/?q=Swarm+Inteligence>`__
--  `Small Acts Manifesto <http://smallactsmanifesto.org/>`__
+-  `Henrique Bastos (DuckDuckGo)`_
+-  `Envy Labs`_
+-  `Ruby on Rails`_
+-  `Code School`_
+-  `JQuery`_
+-  `Ruby`_
+-  `Javascript`_
+-  `Coffee Script`_
+-  `HTML 5`_
+-  `CSS`_
+-  `Responsive Web`_
+-  `Welcome to the Django`_
+-  `Banco de dados`_
+-  `ActiveRecord`_
+-  `LivingSocial`_
+-  `NASA`_
+-  `New York Times`_
+-  `TopWorks`_
+-  `IBM`_
+-  `Rails for Zombies`_
+-  `WordPress`_
+-  `Node.js`_
+-  `Backbone`_
+-  `TryRuby.org`_
+-  `Code TV`_
+-  `Screencast`_
+-  `RailsConf`_
+-  `Python`_
+-  `Rails Testing for Zombies`_
+-  `Interfaces`_
+-  `Tá Safo Conf 2012`_
+-  `Speaker Deck`_
+-  `Capitão América`_
+-  `Thor`_
+-  `Hulk`_
+-  `Netflix`_
+-  `Weeds`_
+-  `HoraExtra`_
+-  `Swarm Inteligence`_
+-  `Small Acts Manifesto`_
 
 .. class:: panel-body bg-info
 
@@ -161,3 +155,65 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _Henrique Bastos: http://www.castalio.info/henrique-bastos-welcome-to-the-django/
+.. _música da banda: https://www.facebook.com/heroeswillfall?sk=app_204974879526524
+.. _Heroes Will Fall: https://www.facebook.com/heroeswillfall
+.. _In Flames: http://www.last.fm/search?q=In+Flames
+.. _Metallica: http://www.last.fm/search?q=Metallica
+.. _Pantera: http://www.last.fm/search?q=Pantera
+.. _Sepultura: http://www.last.fm/search?q=Sepultura
+.. _Pendulum: http://www.last.fm/search?q=Pendulum
+.. _Massive Attack: http://www.last.fm/search?q=Massive+Attack
+.. _Postal Service: http://www.last.fm/search?q=Postal+Service
+.. _Blink 182: http://www.last.fm/search?q=Blink+182
+.. _Gold Finger: http://www.last.fm/search?q=Gold+Finger
+.. _Rancid: http://www.last.fm/search?q=Rancid
+.. _Crash: http://www.imdb.com/find?s=all&q=Crash
+.. _The Avengers: http://www.imdb.com/find?s=all&q=The+Avengers
+.. _Breaking Bad: http://www.imdb.com/find?s=all&q=Breaking+Bad
+.. _United States of Tara: http://www.imdb.com/find?s=all&q=United+States+of+Tara
+.. _Gunslinger: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Gunslinger
+.. _Ramones: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Ramones
+.. _Sepultura (Amazon): http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Sepultura
+.. _Mötley Crüe: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Mötley+Crüe
+.. _Henrique Bastos (DuckDuckGo): https://duckduckgo.com/?q=Henrique+Bastos
+.. _Envy Labs: https://duckduckgo.com/?q=Envy+Labs
+.. _Ruby on Rails: https://duckduckgo.com/?q=Ruby+on+Rails
+.. _Code School: https://duckduckgo.com/?q=Code+School
+.. _JQuery: https://duckduckgo.com/?q=JQuery
+.. _Ruby: https://duckduckgo.com/?q=Ruby
+.. _Javascript: https://duckduckgo.com/?q=Javascript
+.. _Coffee Script: https://duckduckgo.com/?q=Coffee+Script
+.. _HTML 5: https://duckduckgo.com/?q=HTML+5
+.. _CSS: https://duckduckgo.com/?q=CSS
+.. _Responsive Web: https://duckduckgo.com/?q=Responsive+Web
+.. _Welcome to the Django: https://duckduckgo.com/?q=Welcome+to+the+Django
+.. _Banco de dados: https://duckduckgo.com/?q=Banco+de+dados
+.. _ActiveRecord: https://duckduckgo.com/?q=ActiveRecord
+.. _LivingSocial: https://duckduckgo.com/?q=LivingSocial
+.. _NASA: https://duckduckgo.com/?q=NASA
+.. _New York Times: https://duckduckgo.com/?q=New+York+Times
+.. _TopWorks: https://duckduckgo.com/?q=TopWorks
+.. _IBM: https://duckduckgo.com/?q=IBM
+.. _Rails for Zombies: https://duckduckgo.com/?q=Rails+for+Zombies
+.. _WordPress: https://duckduckgo.com/?q=WordPress
+.. _Node.js: https://duckduckgo.com/?q=Node.js
+.. _Backbone: https://duckduckgo.com/?q=Backbone
+.. _TryRuby.org: https://duckduckgo.com/?q=TryRuby.org
+.. _Code TV: https://duckduckgo.com/?q=Code+TV
+.. _Screencast: https://duckduckgo.com/?q=Screencast
+.. _RailsConf: https://duckduckgo.com/?q=RailsConf
+.. _Python: https://duckduckgo.com/?q=Python
+.. _Rails Testing for Zombies: https://duckduckgo.com/?q=Rails+Testing+for+Zombies
+.. _Interfaces: https://duckduckgo.com/?q=Interfaces
+.. _Tá Safo Conf 2012: http://tasafo.org/conf2012/
+.. _Speaker Deck: https://duckduckgo.com/?q=Speaker+Deck
+.. _Capitão América: https://duckduckgo.com/?q=Capitão+América
+.. _Thor: https://duckduckgo.com/?q=Thor
+.. _Hulk: https://duckduckgo.com/?q=Hulk
+.. _Netflix: https://duckduckgo.com/?q=Netflix
+.. _Weeds: https://duckduckgo.com/?q=Weeds
+.. _HoraExtra: https://duckduckgo.com/?q=HoraExtra
+.. _Swarm Inteligence: https://duckduckgo.com/?q=Swarm+Inteligence
+.. _Small Acts Manifesto: http://smallactsmanifesto.org/
+.. _Powerful Interfaces: https://speakerdeck.com/u/caike/p/powerful-interfaces

--- a/content/episodes/037-flavio-ribeiro-globo-com.rst
+++ b/content/episodes/037-flavio-ribeiro-globo-com.rst
@@ -11,14 +11,13 @@ Flávio Ribeiro: Globo.com
 
    Flávio Ribeiro: Globo.com
 
-Eu gosto muito quando alguém me sugere um livro, filme, música ou pessoa
-para conhecer, e depois de trocar uns e-mails com meu amigo `Yuri
-Malheiros <http://www.castalio.info/yuri-malheiros-engenharia-de-software-e-inteligencia-artificial/>`__
-na semana passada, decidi convidar o **Flávio Ribeiro** para uma
-entrevista! O Flávio é um **engenheiro de software** que trabalha na
-**Globo.com** no Rio de Janeiro (na entrevista parecia que ele estava
-sentado bem no meio de **Interlagos** hehehe) e está na equipe
-responsável por toda a área de streaming de conteúdo pela net!
+Eu gosto muito quando alguém me sugere um livro, filme, música ou pessoa para
+conhecer, e depois de trocar uns e-mails com meu amigo `Yuri Malheiros`_ na
+semana passada, decidi convidar o **Flávio Ribeiro** para uma entrevista!
+O Flávio é um **engenheiro de software** que trabalha na **Globo.com** no Rio
+de Janeiro (na entrevista parecia que ele estava sentado bem no meio de
+**Interlagos** hehehe) e está na equipe responsável por toda a área de
+streaming de conteúdo pela net!
 
 Durante nosos bate-papo ele me contou sobre como que sua equipe usa a
 metodologia **SCRUM** para administrar e planejar suas tarefas, quais as
@@ -65,84 +64,84 @@ Resumo
 
 Top 5
 -----
--  **Música:** `The Strokes <http://www.last.fm/search?q=The+Strokes>`__
--  **Música:** `Cooks <http://www.last.fm/search?q=Cooks>`__
--  **Música:** `The Fratellis <http://www.last.fm/search?q=The+Fratellis>`__
--  **Música:** `Some 451 <http://www.last.fm/search?q=Some+451>`__
--  **Música:** `Streetlight Manifesto <http://www.last.fm/search?q=Streetlight+Manifesto>`__
--  **Música:** `Silverchair <http://www.last.fm/search?q=Silverchair>`__
--  **Música:** `Rise Against <http://www.last.fm/search?q=Rise+Against>`__
--  **Música:** `System of a Down <http://www.last.fm/search?q=System+of+a+Down>`__
--  **Música:** `Flogging Molly <http://www.last.fm/search?q=Flogging+Molly>`__
--  **Filmes:** `Family Guy <http://www.imdb.com/find?s=all&q=Family+Guy>`__
--  **Filmes:** `The Cleveland Show <http://www.imdb.com/find?s=all&q=The+Cleveland+Show>`__
--  **Filmes:** `The Walking Dead <http://www.imdb.com/find?s=all&q=The+Walking+Dead>`__
--  **Filmes:** `The Pacific <http://www.imdb.com/find?s=all&q=The+Pacific>`__
--  **Filmes:** `Simpsons <http://www.imdb.com/find?s=all&q=Simpsons>`__
--  **Livros:** `Clean Code <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Clean+Code>`__
--  **Livros:** `The Clean Coder <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=The+Clean+Coder>`__
--  **Livros:** `Land of Lisp <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Land+of+Lisp>`__
--  **Livros:** `Hackers and Painters <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Hackers+and+Painters>`__
--  **Livros:** `Programming Collective Intelligence <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Programming+Collective+Intelligence>`__
+-  **Música:** `The Strokes`_
+-  **Música:** `Cooks`_
+-  **Música:** `The Fratellis`_
+-  **Música:** `Some 451`_
+-  **Música:** `Streetlight Manifesto`_
+-  **Música:** `Silverchair`_
+-  **Música:** `Rise Against`_
+-  **Música:** `System of a Down`_
+-  **Música:** `Flogging Molly`_
+-  **Filmes:** `Family Guy`_
+-  **Filmes:** `The Cleveland Show`_
+-  **Filmes:** `The Walking Dead`_
+-  **Filmes:** `The Pacific`_
+-  **Filmes:** `Simpsons`_
+-  **Livros:** `Clean Code`_
+-  **Livros:** `The Clean Coder`_
+-  **Livros:** `Land of Lisp`_
+-  **Livros:** `Hackers and Painters`_
+-  **Livros:** `Programming Collective Intelligence`_
 
 Links
 -----
--  `Rede Globo <https://duckduckgo.com/?q=Rede+Globo>`__
--  `Scrum <https://duckduckgo.com/?q=Scrum>`__
--  `Big Brother <https://duckduckgo.com/?q=Big+Brother>`__
--  `UFC <https://duckduckgo.com/?q=UFC>`__
--  `Scrum Master <https://duckduckgo.com/?q=Scrum+Master>`__
--  `Code Sprints <https://duckduckgo.com/?q=Code+Sprints>`__
--  `Flash Media Server <https://duckduckgo.com/?q=Flash+Media+Server>`__
--  `Apple <https://duckduckgo.com/?q=Apple>`__
--  `Programação Python <https://duckduckgo.com/?q=Programação+Python>`__
--  `nginx <https://duckduckgo.com/?q=nginx>`__
--  `C/C++ <https://duckduckgo.com/?q=C/C++>`__
--  `Ruby <https://duckduckgo.com/?q=Ruby>`__
--  `Tornado <https://duckduckgo.com/?q=Tornado>`__
--  `Flask <https://duckduckgo.com/?q=Flask>`__
--  `Ruby on Rails <https://duckduckgo.com/?q=Ruby+on+Rails>`__
--  `MongoDB <https://duckduckgo.com/?q=MongoDB>`__
--  `Andrews Medina <https://duckduckgo.com/?q=Andrews+Medina>`__
--  `Python Brasil <https://duckduckgo.com/?q=Python+Brasil>`__
--  `Github <https://duckduckgo.com/?q=Github>`__
--  `Os Trapalhões <https://duckduckgo.com/?q=Os+Trapalhões>`__
--  `Fantástico <https://duckduckgo.com/?q=Fantástico>`__
--  `Domingão do Faustão <https://duckduckgo.com/?q=Domingão+do+Faustão>`__
--  `Globo TV <https://duckduckgo.com/?q=Globo+TV>`__
--  `Youtube <https://duckduckgo.com/?q=Youtube>`__
--  `Fedex Day <https://duckduckgo.com/?q=Fedex+Day>`__
--  `Streaming Media East 2012 <https://duckduckgo.com/?q=Streaming+Media+East+2012>`__
--  `Roku <https://duckduckgo.com/?q=Roku>`__
--  `SDK <https://duckduckgo.com/?q=SDK>`__
--  `MTV <https://duckduckgo.com/?q=MTV>`__
--  `Netflix <https://duckduckgo.com/?q=Netflix>`__
--  `Music Video Awards <https://duckduckgo.com/?q=Music+Video+Awards>`__
--  `Gabriel Falcão <https://duckduckgo.com/?q=Gabriel+Falcão>`__
--  `NY Times <https://duckduckgo.com/?q=NY+Times>`__
--  `NY City <https://duckduckgo.com/?q=NY+City>`__
--  `Brooklyn <https://duckduckgo.com/?q=Brooklyn>`__
--  `Manhattan <https://duckduckgo.com/?q=Manhattan>`__
--  `Bolacha <https://duckduckgo.com/?q=Bolacha>`__
--  `Yipit <https://duckduckgo.com/?q=Yipit>`__
--  `Instagram <https://duckduckgo.com/?q=Instagram>`__
--  `Broadway <https://duckduckgo.com/?q=Broadway>`__
--  `Estátua da Liberdade <https://duckduckgo.com/?q=Estátua+da+Liberdade>`__
--  `Treze Futebol Clube <https://duckduckgo.com/?q=Treze+Futebol+Clube>`__
--  `FX Channel <https://duckduckgo.com/?q=FX+Channel>`__
--  `Fox Channel <https://duckduckgo.com/?q=Fox+Channel>`__
--  `Kindle <https://duckduckgo.com/?q=Kindle>`__
--  `Programação Lisp <https://duckduckgo.com/?q=Programação+Lisp>`__
--  `Clojure <https://duckduckgo.com/?q=Clojure>`__
--  `Stewie <http://cobrateam.github.com/stewie/>`__
--  `4Clojure <https://duckduckgo.com/?q=4Clojure>`__
--  `FISL 13 <https://duckduckgo.com/?q=FISL+13>`__
--  `Objective Oriented Programming <https://duckduckgo.com/?q=Objective+Oriented+Programming>`__
--  `Functional Programming <https://duckduckgo.com/?q=Functional+Programming>`__
--  `Rebel Code <https://duckduckgo.com/?q=Rebel+Code>`__
--  `Richard Stallman <https://duckduckgo.com/?q=Richard+Stallman>`__
--  `Miguel de Icaza <https://duckduckgo.com/?q=Miguel+de+Icaza>`__
--  `Linus Torvald <https://duckduckgo.com/?q=Linus+Torvald>`__
+-  `Rede Globo`_
+-  `Scrum`_
+-  `Big Brother`_
+-  `UFC`_
+-  `Scrum Master`_
+-  `Code Sprints`_
+-  `Flash Media Server`_
+-  `Apple`_
+-  `Programação Python`_
+-  `nginx`_
+-  `C/C++`_
+-  `Ruby`_
+-  `Tornado`_
+-  `Flask`_
+-  `Ruby on Rails`_
+-  `MongoDB`_
+-  `Andrews Medina`_
+-  `Python Brasil`_
+-  `Github`_
+-  `Os Trapalhões`_
+-  `Fantástico`_
+-  `Domingão do Faustão`_
+-  `Globo TV`_
+-  `Youtube`_
+-  `Fedex Day`_
+-  `Streaming Media East 2012`_
+-  `Roku`_
+-  `SDK`_
+-  `MTV`_
+-  `Netflix`_
+-  `Music Video Awards`_
+-  `Gabriel Falcão`_
+-  `NY Times`_
+-  `NY City`_
+-  `Brooklyn`_
+-  `Manhattan`_
+-  `Bolacha`_
+-  `Yipit`_
+-  `Instagram`_
+-  `Broadway`_
+-  `Estátua da Liberdade`_
+-  `Treze Futebol Clube`_
+-  `FX Channel`_
+-  `Fox Channel`_
+-  `Kindle`_
+-  `Programação Lisp`_
+-  `Clojure`_
+-  `Stewie`_
+-  `4Clojure`_
+-  `FISL 13`_
+-  `Objective Oriented Programming`_
+-  `Functional Programming`_
+-  `Rebel Code`_
+-  `Richard Stallman`_
+-  `Miguel de Icaza`_
+-  `Linus Torvald`_
 
 .. class:: panel-body bg-info
 
@@ -151,3 +150,79 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _Yuri Malheiros: http://www.castalio.info/yuri-malheiros-engenharia-de-software-e-inteligencia-artificial/
+.. _The Strokes: http://www.last.fm/search?q=The+Strokes
+.. _Cooks: http://www.last.fm/search?q=Cooks
+.. _The Fratellis: http://www.last.fm/search?q=The+Fratellis
+.. _Some 451: http://www.last.fm/search?q=Some+451
+.. _Streetlight Manifesto: http://www.last.fm/search?q=Streetlight+Manifesto
+.. _Silverchair: http://www.last.fm/search?q=Silverchair
+.. _Rise Against: http://www.last.fm/search?q=Rise+Against
+.. _System of a Down: http://www.last.fm/search?q=System+of+a+Down
+.. _Flogging Molly: http://www.last.fm/search?q=Flogging+Molly
+.. _Family Guy: http://www.imdb.com/find?s=all&q=Family+Guy
+.. _The Cleveland Show: http://www.imdb.com/find?s=all&q=The+Cleveland+Show
+.. _The Walking Dead: http://www.imdb.com/find?s=all&q=The+Walking+Dead
+.. _The Pacific: http://www.imdb.com/find?s=all&q=The+Pacific
+.. _Simpsons: http://www.imdb.com/find?s=all&q=Simpsons
+.. _Clean Code: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Clean+Code
+.. _The Clean Coder: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=The+Clean+Coder
+.. _Land of Lisp: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Land+of+Lisp
+.. _Hackers and Painters: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Hackers+and+Painters
+.. _Programming Collective Intelligence: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Programming+Collective+Intelligence
+.. _Rede Globo: https://duckduckgo.com/?q=Rede+Globo
+.. _Scrum: https://duckduckgo.com/?q=Scrum
+.. _Big Brother: https://duckduckgo.com/?q=Big+Brother
+.. _UFC: https://duckduckgo.com/?q=UFC
+.. _Scrum Master: https://duckduckgo.com/?q=Scrum+Master
+.. _Code Sprints: https://duckduckgo.com/?q=Code+Sprints
+.. _Flash Media Server: https://duckduckgo.com/?q=Flash+Media+Server
+.. _Apple: https://duckduckgo.com/?q=Apple
+.. _Programação Python: https://duckduckgo.com/?q=Programação+Python
+.. _nginx: https://duckduckgo.com/?q=nginx
+.. _C/C++: https://duckduckgo.com/?q=C/C++
+.. _Ruby: https://duckduckgo.com/?q=Ruby
+.. _Tornado: https://duckduckgo.com/?q=Tornado
+.. _Flask: https://duckduckgo.com/?q=Flask
+.. _Ruby on Rails: https://duckduckgo.com/?q=Ruby+on+Rails
+.. _MongoDB: https://duckduckgo.com/?q=MongoDB
+.. _Andrews Medina: https://duckduckgo.com/?q=Andrews+Medina
+.. _Python Brasil: https://duckduckgo.com/?q=Python+Brasil
+.. _Github: https://duckduckgo.com/?q=Github
+.. _Os Trapalhões: https://duckduckgo.com/?q=Os+Trapalhões
+.. _Fantástico: https://duckduckgo.com/?q=Fantástico
+.. _Domingão do Faustão: https://duckduckgo.com/?q=Domingão+do+Faustão
+.. _Globo TV: https://duckduckgo.com/?q=Globo+TV
+.. _Youtube: https://duckduckgo.com/?q=Youtube
+.. _Fedex Day: https://duckduckgo.com/?q=Fedex+Day
+.. _Streaming Media East 2012: https://duckduckgo.com/?q=Streaming+Media+East+2012
+.. _Roku: https://duckduckgo.com/?q=Roku
+.. _SDK: https://duckduckgo.com/?q=SDK
+.. _MTV: https://duckduckgo.com/?q=MTV
+.. _Netflix: https://duckduckgo.com/?q=Netflix
+.. _Music Video Awards: https://duckduckgo.com/?q=Music+Video+Awards
+.. _Gabriel Falcão: https://duckduckgo.com/?q=Gabriel+Falcão
+.. _NY Times: https://duckduckgo.com/?q=NY+Times
+.. _NY City: https://duckduckgo.com/?q=NY+City
+.. _Brooklyn: https://duckduckgo.com/?q=Brooklyn
+.. _Manhattan: https://duckduckgo.com/?q=Manhattan
+.. _Bolacha: https://duckduckgo.com/?q=Bolacha
+.. _Yipit: https://duckduckgo.com/?q=Yipit
+.. _Instagram: https://duckduckgo.com/?q=Instagram
+.. _Broadway: https://duckduckgo.com/?q=Broadway
+.. _Estátua da Liberdade: https://duckduckgo.com/?q=Estátua+da+Liberdade
+.. _Treze Futebol Clube: https://duckduckgo.com/?q=Treze+Futebol+Clube
+.. _FX Channel: https://duckduckgo.com/?q=FX+Channel
+.. _Fox Channel: https://duckduckgo.com/?q=Fox+Channel
+.. _Kindle: https://duckduckgo.com/?q=Kindle
+.. _Programação Lisp: https://duckduckgo.com/?q=Programação+Lisp
+.. _Clojure: https://duckduckgo.com/?q=Clojure
+.. _Stewie: http://cobrateam.github.com/stewie/
+.. _4Clojure: https://duckduckgo.com/?q=4Clojure
+.. _FISL 13: https://duckduckgo.com/?q=FISL+13
+.. _Objective Oriented Programming: https://duckduckgo.com/?q=Objective+Oriented+Programming
+.. _Functional Programming: https://duckduckgo.com/?q=Functional+Programming
+.. _Rebel Code: https://duckduckgo.com/?q=Rebel+Code
+.. _Richard Stallman: https://duckduckgo.com/?q=Richard+Stallman
+.. _Miguel de Icaza: https://duckduckgo.com/?q=Miguel+de+Icaza
+.. _Linus Torvald: https://duckduckgo.com/?q=Linus+Torvald

--- a/content/episodes/038-felipe-ribeiro-spotify.rst
+++ b/content/episodes/038-felipe-ribeiro-spotify.rst
@@ -12,17 +12,13 @@ Felipe Ribeiro: Spotify
    Felipe Ribeiro: Spotify
 
 Olá pessoal e sejam muito bem-vindos à mais um episódio! Desta vez para
-comemorar o meu aniversário (que foi no dia 8 de junho, mas ainda há
-tempo para comprar o meu
-`presente <http://www.amazon.com/gp/registry/wishlist/32BX7VP2GEFI1/ref=topnav_lists_1>`__
-hehehe) tive a chance de conversar com o **Felipe Ribeiro**, o único
-Brasileiro que trabalha na companhia
-`Spotify <http://www.spotify.com/>`__ ! O Felipe é irmão do **Flávio
-Ribeiro** que eu entrevistei no `último
-episódio <http://www.castalio.info/flavio-ribeiro-globo-com/>`__, o que
-me leva a pensar que existe um movimento muito forte na **Paraíba** nas
-áreas de educação e software livre, já que foram várias pessoas da
-região que passaram por aqui. :)
+comemorar o meu aniversário (que foi no dia 8 de junho, mas ainda há tempo para
+comprar o meu `presente`_ hehehe) tive a chance de conversar com o **Felipe
+Ribeiro**, o único Brasileiro que trabalha na companhia `Spotify`_ ! O Felipe
+é irmão do **Flávio Ribeiro** que eu entrevistei no `último episódio`_, o que
+me leva a pensar que existe um movimento muito forte na **Paraíba** nas áreas
+de educação e software livre, já que foram várias pessoas da região que
+passaram por aqui. :)
 
 .. more
 
@@ -70,42 +66,42 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Pearl Jam <http://www.last.fm/search?q=Pearl+Jam>`__
--  **Música:** `Wolfmother <http://www.last.fm/search?q=Wolfmother>`__
--  **Música:** `AC/DC <http://www.last.fm/search?q=AC/DC>`__
--  **Música:** `Creedence Clearwater Revival <http://www.last.fm/search?q=Creedence+Clearwater+Revival>`__
--  **Música:** `Explosions in the Sky <http://www.last.fm/search?q=Explosions+in+the+Sky>`__
--  **Filmes:** `Forrest Gump <http://www.imdb.com/find?s=all&q=Forrest+Gump>`__
--  **Filmes:** `Back to the future <http://www.imdb.com/find?s=all&q=Back+to+the+future>`__
--  **Filmes:** `Inception <http://www.imdb.com/find?s=all&q=Inception>`__
--  **Filmes:** `The Big Lebowski <http://www.imdb.com/find?s=all&q=The+Big+Lebowski>`__
--  **Filmes:** `The Good, the Bad and the Ugly <http://www.imdb.com/find?s=all&q=The+Good,+the+Bad+and+the+Ugly>`__
--  **Livros:** `Programming pearls <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Programming+pearls>`__
--  **Livros:** `The algorithm design manual <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=The+algorithm+design+manual>`__
--  **Livros:** `Being Geek <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Being+Geek>`__
--  **Livros:** `The Hichhiker\'s guide to the galaxy <https://www.goodreads.com/book/show/11.The_Hitchhiker_s_Guide_to_the_Galaxy>`__
--  **Livros:** `Starman: Truth Behind the Legend of Yuri Gagarin <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Starman:+Truth+Behind+the+Legend+of+Yuri+Gagarin>`__
--  **Livros:** `Ensaio sobre a cegueira <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Ensaio+sobre+a+cegueira>`__
+-  **Música:** `Pearl Jam`_
+-  **Música:** `Wolfmother`_
+-  **Música:** `AC/DC`_
+-  **Música:** `Creedence Clearwater Revival`_
+-  **Música:** `Explosions in the Sky`_
+-  **Filmes:** `Forrest Gump`_
+-  **Filmes:** `Back to the future`_
+-  **Filmes:** `Inception`_
+-  **Filmes:** `The Big Lebowski`_
+-  **Filmes:** `The Good, the Bad and the Ugly`_
+-  **Livros:** `Programming pearls`_
+-  **Livros:** `The algorithm design manual`_
+-  **Livros:** `Being Geek`_
+-  **Livros:** `The Hichhiker\'s guide to the galaxy`_
+-  **Livros:** `Starman - Truth Behind the Legend of Yuri Gagarin`_
+-  **Livros:** `Ensaio sobre a cegueira`_
 
 Links
 -----
--  `Flávio Ribeiro <https://duckduckgo.com/?q=Flávio+Ribeiro>`__
--  `Spotify <https://duckduckgo.com/?q=Spotify>`__
--  `Tuenti <https://duckduckgo.com/?q=Tuenti>`__
--  `PHP <https://duckduckgo.com/?q=PHP>`__
--  `Java Script <https://duckduckgo.com/?q=Java+Script>`__
--  `MySQL <https://duckduckgo.com/?q=MySQL>`__
--  `Memcache <https://duckduckgo.com/?q=Memcache>`__
--  `FISL <https://duckduckgo.com/?q=FISL>`__
--  `PHP Conference <https://duckduckgo.com/?q=PHP+Conference>`__
--  `Linkedin <https://duckduckgo.com/?q=Linkedin>`__
--  `Caike Souza <https://duckduckgo.com/?q=Caike+Souza>`__
--  `Facebook <https://duckduckgo.com/?q=Facebook>`__
--  `Youtube <https://duckduckgo.com/?q=Youtube>`__
--  `Rdio <https://duckduckgo.com/?q=Rdio>`__
--  `Pandora <https://duckduckgo.com/?q=Pandora>`__
--  `Groove Shark <https://duckduckgo.com/?q=Groove+Shark>`__
--  `Will Farrel <https://duckduckgo.com/?q=Will+Farrel>`__
+-  `Flávio Ribeiro`_
+-  `Spotify (DuckDuckGo)`_
+-  `Tuenti`_
+-  `PHP`_
+-  `Java Script`_
+-  `MySQL`_
+-  `Memcache`_
+-  `FISL`_
+-  `PHP Conference`_
+-  `Linkedin`_
+-  `Caike Souza`_
+-  `Facebook`_
+-  `Youtube`_
+-  `Rdio`_
+-  `Pandora`_
+-  `Groove Shark`_
+-  `Will Farrel`_
 
 .. class:: panel-body bg-info
 
@@ -114,3 +110,39 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _presente: http://www.amazon.com/gp/registry/wishlist/32BX7VP2GEFI1/ref=topnav_lists_1
+.. _Spotify: http://www.spotify.com/
+.. _último episódio: http://www.castalio.info/flavio-ribeiro-globo-com/
+.. _Pearl Jam: http://www.last.fm/search?q=Pearl+Jam
+.. _Wolfmother: http://www.last.fm/search?q=Wolfmother
+.. _AC/DC: http://www.last.fm/search?q=AC/DC
+.. _Creedence Clearwater Revival: http://www.last.fm/search?q=Creedence+Clearwater+Revival
+.. _Explosions in the Sky: http://www.last.fm/search?q=Explosions+in+the+Sky
+.. _Forrest Gump: http://www.imdb.com/find?s=all&q=Forrest+Gump
+.. _Back to the future: http://www.imdb.com/find?s=all&q=Back+to+the+future
+.. _Inception: http://www.imdb.com/find?s=all&q=Inception
+.. _The Big Lebowski: http://www.imdb.com/find?s=all&q=The+Big+Lebowski
+.. _The Good, the Bad and the Ugly: http://www.imdb.com/find?s=all&q=The+Good,+the+Bad+and+the+Ugly
+.. _Programming pearls: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Programming+pearls
+.. _The algorithm design manual: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=The+algorithm+design+manual
+.. _Being Geek: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Being+Geek
+.. _The Hichhiker\'s guide to the galaxy: https://www.goodreads.com/book/show/11.The_Hitchhiker_s_Guide_to_the_Galaxy
+.. _Starman - Truth Behind the Legend of Yuri Gagarin: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Starman:+Truth+Behind+the+Legend+of+Yuri+Gagarin
+.. _Ensaio sobre a cegueira: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Ensaio+sobre+a+cegueira
+.. _Flávio Ribeiro: https://duckduckgo.com/?q=Flávio+Ribeiro
+.. _Spotify (DuckDuckGo): https://duckduckgo.com/?q=Spotify
+.. _Tuenti: https://duckduckgo.com/?q=Tuenti
+.. _PHP: https://duckduckgo.com/?q=PHP
+.. _Java Script: https://duckduckgo.com/?q=Java+Script
+.. _MySQL: https://duckduckgo.com/?q=MySQL
+.. _Memcache: https://duckduckgo.com/?q=Memcache
+.. _FISL: https://duckduckgo.com/?q=FISL
+.. _PHP Conference: https://duckduckgo.com/?q=PHP+Conference
+.. _Linkedin: https://duckduckgo.com/?q=Linkedin
+.. _Caike Souza: https://duckduckgo.com/?q=Caike+Souza
+.. _Facebook: https://duckduckgo.com/?q=Facebook
+.. _Youtube: https://duckduckgo.com/?q=Youtube
+.. _Rdio: https://duckduckgo.com/?q=Rdio
+.. _Pandora: https://duckduckgo.com/?q=Pandora
+.. _Groove Shark: https://duckduckgo.com/?q=Groove+Shark
+.. _Will Farrel: https://duckduckgo.com/?q=Will+Farrel

--- a/content/episodes/039-djavan-fagundes-gnome-brasil.rst
+++ b/content/episodes/039-djavan-fagundes-gnome-brasil.rst
@@ -11,22 +11,17 @@ Djavan Fagundes: GNOME Brasil
 
    Djavan Fagundes: GNOME Brasil
 
-Olá pessoal e sejam muito bem-vindos à mais um episódio, desta vez com
-uma novidade: vídeo com os bastidores e a prórpria entrevista pelo
-**Youtube**! Deixa eu explicar melhor! Depois que vi o último episódio
-do `Hora do Mac (HDM) <http://www.horadomac.com/>`__ sendo gravado ao
-vivo pelo Youtube usando o **Google Hangout**, decidi tentar fazer a
-mesma coisa para que as pessoas possam ver como que as entrevistas
-acontecem e poderem também participar com perguntas durante a gravação.
-Foi uma pena que na última hora meu convidado não pode usar um
-computador e acabou que o `primeiro
-vídeo <https://www.youtube.com/watch?feature=player_embedded&v=qmwKZKb0f-Y>`__
-só tem uma pessoa: eu! :) Mas beleza, acho que já para o próximo
-episódio dá para fazer da forma que eu quero! Então depois não se
-esqueçam de adicionar este podcast aqui no\ `Google
-Plus <https://plus.google.com/107864992170817866192/posts>`__ e
-`Twitter <https://twitter.com/#!/castaliopod>`__ para saberem quando a
-próxima gravação será feita.
+Olá pessoal e sejam muito bem-vindos à mais um episódio, desta vez com uma
+novidade: vídeo com os bastidores e a prórpria entrevista pelo **Youtube**!
+Deixa eu explicar melhor! Depois que vi o último episódio do `Hora do Mac
+(HDM)`_ sendo gravado ao vivo pelo Youtube usando o **Google Hangout**, decidi
+tentar fazer a mesma coisa para que as pessoas possam ver como que as
+entrevistas acontecem e poderem também participar com perguntas durante
+a gravação.  Foi uma pena que na última hora meu convidado não pode usar um
+computador e acabou que o `primeiro vídeo`_ só tem uma pessoa: eu! :) Mas
+beleza, acho que já para o próximo episódio dá para fazer da forma que eu
+quero! Então depois não se esqueçam de adicionar este podcast aqui no\ `Google
+Plus`_ e `Twitter`_ para saberem quando a próxima gravação será feita.
 
 .. more
 
@@ -70,44 +65,44 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Creedence Clearwater Revival <http://www.last.fm/search?q=Creedence+Clearwater+Revival>`__
--  **Música:** `Led Zeppelin <http://www.last.fm/search?q=Led+Zeppelin>`__
--  **Música:** `Raul Seixas <http://www.last.fm/search?q=Raul+Seixas>`__
--  **Música:** `The Raincoats <http://www.last.fm/search?q=The+Raincoats>`__
--  **Filmes:** `Chaves <http://www.imdb.com/find?s=all&q=Chaves>`__
--  **Filmes:** `The IT Crowd <http://www.imdb.com/find?s=all&q=The+IT+Crowd>`__
--  **Filmes:** `Breaking Bad <http://www.imdb.com/find?s=all&q=Breaking+Bad>`__
--  **Filmes:** `Pedro Almodóvar <http://www.imdb.com/find?s=all&q=Pedro+Almodóvar>`__
--  **Filmes:** `Sin City <http://www.imdb.com/find?s=all&q=Sin+City>`__
--  **Filmes:** `Hell Boy <http://www.imdb.com/find?s=all&q=Hell+Boy>`__
--  **Filmes:** `Constantine <http://www.imdb.com/find?s=all&q=Constantine>`__
--  **Livros:** `Rubem Alves <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Rubem+Alves>`__
--  **Livros:** `Gandhi: A Magia dos gestos poéticos <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Gandhi:+A+Magia+dos+gestos+poéticos>`__
--  **Livros:** `Casa 21 <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Casa+21>`__
--  **Livros:** `Cidades Ilustradas <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Cidades+Ilustradas>`__
--  **Livros:** `Oscar Wilde <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Oscar+Wilde>`__
--  **Livros:** `The Picture of Dorian Gray <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=The+Picture+of+Dorian+Gray>`__
+-  **Música:** `Creedence Clearwater Revival`_
+-  **Música:** `Led Zeppelin`_
+-  **Música:** `Raul Seixas`_
+-  **Música:** `The Raincoats`_
+-  **Filmes:** `Chaves`_
+-  **Filmes:** `The IT Crowd`_
+-  **Filmes:** `Breaking Bad`_
+-  **Filmes:** `Pedro Almodóvar`_
+-  **Filmes:** `Sin City`_
+-  **Filmes:** `Hell Boy`_
+-  **Filmes:** `Constantine`_
+-  **Livros:** `Rubem Alves`_
+-  **Livros:** `Gandhi - A Magia dos gestos poéticos`_
+-  **Livros:** `Casa 21`_
+-  **Livros:** `Cidades Ilustradas`_
+-  **Livros:** `Oscar Wilde`_
+-  **Livros:** `The Picture of Dorian Gray`_
 
 Links
 -----
--  `Ambiente GNOME <https://duckduckgo.com/?q=Ambiente+GNOME>`__
--  `GNOME Brasil <https://duckduckgo.com/?q=GNOME+Brasil>`__
--  `Jonh Wendell <https://duckduckgo.com/?q=Jonh+Wendell>`__
--  `Ambiente KDE <https://duckduckgo.com/?q=Ambiente+KDE>`__
--  `Ambiente XFCE <https://duckduckgo.com/?q=Ambiente+XFCE>`__
--  `Distribuição Arch Linux <https://duckduckgo.com/?q=Distribuição+Arch+Linux>`__
--  `Distribuição Debian Linux <https://duckduckgo.com/?q=Distribuição+Debian+Linux>`__
--  `Distribuição Foresight Linux <https://duckduckgo.com/?q=Distribuição+Foresight+Linux>`__
--  `Distribuição Fedora Linux <https://duckduckgo.com/?q=Distribuição+Fedora+Linux>`__
--  `GNOME 3 <https://duckduckgo.com/?q=GNOME+3>`__
--  `Linus Torvalds <https://duckduckgo.com/?q=Linus+Torvalds>`__
--  `gnome-tweak-tool <https://duckduckgo.com/?q=gnome-tweak-tool>`__
--  `Ambiente Openbox <https://duckduckgo.com/?q=Ambiente+Openbox>`__
--  `OpenStreet Map <https://duckduckgo.com/?q=OpenStreet+Map>`__
--  `Belo Horizonte <https://duckduckgo.com/?q=Belo+Horizonte>`__
--  `Mapping Party <https://duckduckgo.com/?q=Mapping+Party>`__
--  `Google Maps <https://duckduckgo.com/?q=Google+Maps>`__
--  `The Big Bang Theory <https://duckduckgo.com/?q=The+Big+Bang+Theory>`__
+-  `Ambiente GNOME`_
+-  `GNOME Brasil`_
+-  `Jonh Wendell`_
+-  `Ambiente KDE`_
+-  `Ambiente XFCE`_
+-  `Distribuição Arch Linux`_
+-  `Distribuição Debian Linux`_
+-  `Distribuição Foresight Linux`_
+-  `Distribuição Fedora Linux`_
+-  `GNOME 3`_
+-  `Linus Torvalds`_
+-  `gnome-tweak-tool`_
+-  `Ambiente Openbox`_
+-  `OpenStreet Map`_
+-  `Belo Horizonte`_
+-  `Mapping Party`_
+-  `Google Maps`_
+-  `The Big Bang Theory`_
 
 .. class:: panel-body bg-info
 
@@ -116,3 +111,42 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _Hora do Mac (HDM): http://www.horadomac.com/
+.. _primeiro vídeo: https://www.youtube.com/watch?feature=player_embedded&v=qmwKZKb0f-Y
+.. _Google Plus: https://plus.google.com/107864992170817866192/posts
+.. _Twitter: https://twitter.com/#!/castaliopod
+.. _Creedence Clearwater Revival: http://www.last.fm/search?q=Creedence+Clearwater+Revival
+.. _Led Zeppelin: http://www.last.fm/search?q=Led+Zeppelin
+.. _Raul Seixas: http://www.last.fm/search?q=Raul+Seixas
+.. _The Raincoats: http://www.last.fm/search?q=The+Raincoats
+.. _Chaves: http://www.imdb.com/find?s=all&q=Chaves
+.. _The IT Crowd: http://www.imdb.com/find?s=all&q=The+IT+Crowd
+.. _Breaking Bad: http://www.imdb.com/find?s=all&q=Breaking+Bad
+.. _Pedro Almodóvar: http://www.imdb.com/find?s=all&q=Pedro+Almodóvar
+.. _Sin City: http://www.imdb.com/find?s=all&q=Sin+City
+.. _Hell Boy: http://www.imdb.com/find?s=all&q=Hell+Boy
+.. _Constantine: http://www.imdb.com/find?s=all&q=Constantine
+.. _Rubem Alves: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Rubem+Alves
+.. _Gandhi - A Magia dos gestos poéticos: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Gandhi:+A+Magia+dos+gestos+poéticos
+.. _Casa 21: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Casa+21
+.. _Cidades Ilustradas: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Cidades+Ilustradas
+.. _Oscar Wilde: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Oscar+Wilde
+.. _The Picture of Dorian Gray: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=The+Picture+of+Dorian+Gray
+.. _Ambiente GNOME: https://duckduckgo.com/?q=Ambiente+GNOME
+.. _GNOME Brasil: https://duckduckgo.com/?q=GNOME+Brasil
+.. _Jonh Wendell: https://duckduckgo.com/?q=Jonh+Wendell
+.. _Ambiente KDE: https://duckduckgo.com/?q=Ambiente+KDE
+.. _Ambiente XFCE: https://duckduckgo.com/?q=Ambiente+XFCE
+.. _Distribuição Arch Linux: https://duckduckgo.com/?q=Distribuição+Arch+Linux
+.. _Distribuição Debian Linux: https://duckduckgo.com/?q=Distribuição+Debian+Linux
+.. _Distribuição Foresight Linux: https://duckduckgo.com/?q=Distribuição+Foresight+Linux
+.. _Distribuição Fedora Linux: https://duckduckgo.com/?q=Distribuição+Fedora+Linux
+.. _GNOME 3: https://duckduckgo.com/?q=GNOME+3
+.. _Linus Torvalds: https://duckduckgo.com/?q=Linus+Torvalds
+.. _gnome-tweak-tool: https://duckduckgo.com/?q=gnome-tweak-tool
+.. _Ambiente Openbox: https://duckduckgo.com/?q=Ambiente+Openbox
+.. _OpenStreet Map: https://duckduckgo.com/?q=OpenStreet+Map
+.. _Belo Horizonte: https://duckduckgo.com/?q=Belo+Horizonte
+.. _Mapping Party: https://duckduckgo.com/?q=Mapping+Party
+.. _Google Maps: https://duckduckgo.com/?q=Google+Maps
+.. _The Big Bang Theory: https://duckduckgo.com/?q=The+Big+Bang+Theory

--- a/content/episodes/040-danilo-resende-facebook.rst
+++ b/content/episodes/040-danilo-resende-facebook.rst
@@ -11,11 +11,10 @@ Danilo Resende: Facebook
 
    Danilo Resende: Facebook
 
-Olá pessoal e sejam muito bem-vindos à mais um episódio, mais uma vez
-com uma novidade: uma participação especial do \ **Ivan Brasil Fuzzer**,
-criador e mantenedor do web site de dicas e tutoriais
- `Ubuntero <http://www.ubuntero.com.br>`__! Com uma conexão **Carolina
-do Norte** - **Rio Grande do Sul** - **Califórnia**, batemos um papo
+Olá pessoal e sejam muito bem-vindos à mais um episódio, mais uma vez com uma
+novidade: uma participação especial do **Ivan Brasil Fuzzer**, criador
+e mantenedor do web site de dicas e tutoriais  `Ubuntero`_! Com uma conexão
+**Carolina do Norte** - **Rio Grande do Sul** - **Califórnia**, batemos um papo
 muito legal com o **Danilo Resende** do **Facebook**!
 
 Durante nosso bate-papo, conversamos sobre como que o Danilo começou sua
@@ -30,7 +29,7 @@ A entrevista toda foi tambêm gravada pelo **Youtube** ao vivo e à cores,
 com participação de alguns ouvintes e até mesmo perguntas dos ouvintes e
 algumas falhas (que foram editadas no áudio hehehe). Assistam ao
 episódio
-`aqui <http://www.youtube.com/watch?v=4aYZTH93OMg&feature=plcp>`__!
+`aqui`_!
 
 Escute Agora
 ------------
@@ -59,40 +58,40 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Samba <http://www.last.fm/search?q=Samba>`__
--  **Música:** `Martinho da Vila <http://www.last.fm/search?q=Martinho+da+Vila>`__
--  **Música:** `Dominguinhos <http://www.last.fm/search?q=Dominguinhos>`__
--  **Música:** `Jack Johnson <http://www.last.fm/search?q=Jack+Johnson>`__
--  **Música:** `Ben Harper <http://www.last.fm/search?q=Ben+Harper>`__
--  **Música:** `Yamandu Costa <http://www.last.fm/search?q=Yamandu+Costa>`__
--  **Filmes:** `O Poderoso Chefão I <http://www.imdb.com/find?s=all&q=O+Poderoso+Chefão+I>`__
--  **Filmes:** `O Poderoso Chefão II <http://www.imdb.com/find?s=all&q=O+Poderoso+Chefão+II>`__
--  **Filmes:** `O Clube da Luta <http://www.imdb.com/find?s=all&q=O+Clube+da+Luta>`__
--  **Filmes:** `Inception <http://www.imdb.com/find?s=all&q=Inception>`__
--  **Filmes:** `Amelie <http://www.imdb.com/find?s=all&q=Amelie>`__
--  **Livros:** `Introdução a Algorítimos <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Introdução+a+Algorítimos>`__
--  **Livros:** `Programming Perl <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Programming+Perl>`__
--  **Livros:** `Zen, The Art of Motocycle Repair <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Zen,+The+Art+of+Motocycle+Repair>`__
--  **Livros:** `Pelejas de Ojuara, o Homem que Desafiou o Diabo <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Pelejas+de+Ojuara,+o+Homem+que+Desafiou+o+Diabo>`__
--  **Livros:** `The Visual Display of Quantitative Information <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=The+Visual+Display+of+Quantitative+Information>`__
+-  **Música:** `Samba`_
+-  **Música:** `Martinho da Vila`_
+-  **Música:** `Dominguinhos`_
+-  **Música:** `Jack Johnson`_
+-  **Música:** `Ben Harper`_
+-  **Música:** `Yamandu Costa`_
+-  **Filmes:** `O Poderoso Chefão I`_
+-  **Filmes:** `O Poderoso Chefão II`_
+-  **Filmes:** `O Clube da Luta`_
+-  **Filmes:** `Inception`_
+-  **Filmes:** `Amelie`_
+-  **Livros:** `Introdução a Algorítimos`_
+-  **Livros:** `Programming Perl`_
+-  **Livros:** `Zen, The Art of Motocycle Repair`_
+-  **Livros:** `Pelejas de Ojuara, o Homem que Desafiou o Diabo`_
+-  **Livros:** `The Visual Display of Quantitative Information`_
 
 Links
 -----
--  `Ubuntero <https://duckduckgo.com/?q=Ubuntero>`__
--  `Youtube <https://duckduckgo.com/?q=Youtube>`__
--  `Facebook <https://duckduckgo.com/?q=Facebook>`__
--  `Universidade Federal de Campinas Grande <https://duckduckgo.com/?q=Universidade+Federal+de+Campinas+Grande>`__
--  `Non Disclosure Agreement <https://duckduckgo.com/?q=Non+Disclosure+Agreement>`__
--  `Sistema de Controle de Versão <https://duckduckgo.com/?q=Sistema+de+Controle+de+Versão>`__
--  `Javascript <https://duckduckgo.com/?q=Javascript>`__
--  `API <https://duckduckgo.com/?q=API>`__
--  `Vale do Silício <https://duckduckgo.com/?q=Vale+do+Silício>`__
--  `Flávio Ribeiro <https://duckduckgo.com/?q=Flávio+Ribeiro>`__
--  `Netflix <https://duckduckgo.com/?q=Netflix>`__
--  `Hackathon <https://duckduckgo.com/?q=Hackathon>`__
--  `A Rede Social <https://duckduckgo.com/?q=A+Rede+Social>`__
--  `Mark Zuckerberg <https://duckduckgo.com/?q=Mark+Zuckerberg>`__
--  `Skype <https://duckduckgo.com/?q=Skype>`__
+-  `Ubuntero (DuckDuckGo)`_
+-  `Youtube`_
+-  `Facebook`_
+-  `Universidade Federal de Campinas Grande`_
+-  `Non Disclosure Agreement`_
+-  `Sistema de Controle de Versão`_
+-  `Javascript`_
+-  `API`_
+-  `Vale do Silício`_
+-  `Flávio Ribeiro`_
+-  `Netflix`_
+-  `Hackathon`_
+-  `A Rede Social`_
+-  `Mark Zuckerberg`_
+-  `Skype`_
 
 .. class:: panel-body bg-info
 
@@ -101,3 +100,36 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _Ubuntero: http://www.ubuntero.com.br
+.. _aqui: http://www.youtube.com/watch?v=4aYZTH93OMg&feature=plcp
+.. _Samba: http://www.last.fm/search?q=Samba
+.. _Martinho da Vila: http://www.last.fm/search?q=Martinho+da+Vila
+.. _Dominguinhos: http://www.last.fm/search?q=Dominguinhos
+.. _Jack Johnson: http://www.last.fm/search?q=Jack+Johnson
+.. _Ben Harper: http://www.last.fm/search?q=Ben+Harper
+.. _Yamandu Costa: http://www.last.fm/search?q=Yamandu+Costa
+.. _O Poderoso Chefão I: http://www.imdb.com/find?s=all&q=O+Poderoso+Chefão+I
+.. _O Poderoso Chefão II: http://www.imdb.com/find?s=all&q=O+Poderoso+Chefão+II
+.. _O Clube da Luta: http://www.imdb.com/find?s=all&q=O+Clube+da+Luta
+.. _Inception: http://www.imdb.com/find?s=all&q=Inception
+.. _Amelie: http://www.imdb.com/find?s=all&q=Amelie
+.. _Introdução a Algorítimos: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Introdução+a+Algorítimos
+.. _Programming Perl: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Programming+Perl
+.. _Zen, The Art of Motocycle Repair: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Zen,+The+Art+of+Motocycle+Repair
+.. _Pelejas de Ojuara, o Homem que Desafiou o Diabo: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Pelejas+de+Ojuara,+o+Homem+que+Desafiou+o+Diabo
+.. _The Visual Display of Quantitative Information: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=The+Visual+Display+of+Quantitative+Information
+.. _Ubuntero (DuckDuckGo): https://duckduckgo.com/?q=Ubuntero
+.. _Youtube: https://duckduckgo.com/?q=Youtube
+.. _Facebook: https://duckduckgo.com/?q=Facebook
+.. _Universidade Federal de Campinas Grande: https://duckduckgo.com/?q=Universidade+Federal+de+Campinas+Grande
+.. _Non Disclosure Agreement: https://duckduckgo.com/?q=Non+Disclosure+Agreement
+.. _Sistema de Controle de Versão: https://duckduckgo.com/?q=Sistema+de+Controle+de+Versão
+.. _Javascript: https://duckduckgo.com/?q=Javascript
+.. _API: https://duckduckgo.com/?q=API
+.. _Vale do Silício: https://duckduckgo.com/?q=Vale+do+Silício
+.. _Flávio Ribeiro: https://duckduckgo.com/?q=Flávio+Ribeiro
+.. _Netflix: https://duckduckgo.com/?q=Netflix
+.. _Hackathon: https://duckduckgo.com/?q=Hackathon
+.. _A Rede Social: https://duckduckgo.com/?q=A+Rede+Social
+.. _Mark Zuckerberg: https://duckduckgo.com/?q=Mark+Zuckerberg
+.. _Skype: https://duckduckgo.com/?q=Skype

--- a/content/episodes/041-fabio-nogueira-ubuntu-brasil.rst
+++ b/content/episodes/041-fabio-nogueira-ubuntu-brasil.rst
@@ -11,18 +11,15 @@ Fábio Nogueira: Ubuntu Brasil
 
    Fábio Nogueira: Ubuntu Brasil
 
-**Atualização**: Faltou o link do
-`vídeo <http://www.youtube.com/watch?v=Dgf8Bvn8tYI>`__ da entrevista! :)
+**Atualização**: Faltou o link do `vídeo`_ da entrevista! :)
 
-Olá pessoal e sejam muito bem-vindos à mais um episódio! No começo deste
-ano eu tinha prometido fazer uma série especial sobre os primeiros
-membros do **Ubuntu Brasil** e como tudo começou (quem ainda não escutou
-o episódio com o `Rodrigo
-Belém <http://www.castalio.info/rodrigo-belem-ubuntu-brasil/>`__?), mas
-nem sempre é fácil conseguir arrumar um tempinho para bater um papo com
-estas pessoas. Felizmente, nesta última semana, consegui bater um papo
-com o **Fábio Nogueira**, um dos primeiros integrantes e membro das
-primeiras "safras" de pioneiros da comunidade Ubuntu Brasil!
+Olá pessoal e sejam muito bem-vindos à mais um episódio! No começo deste ano eu
+tinha prometido fazer uma série especial sobre os primeiros membros do **Ubuntu
+Brasil** e como tudo começou (quem ainda não escutou o episódio com o `Rodrigo
+Belém`_?), mas nem sempre é fácil conseguir arrumar um tempinho para bater um
+papo com estas pessoas. Felizmente, nesta última semana, consegui bater um papo
+com o **Fábio Nogueira**, um dos primeiros integrantes e membro das primeiras
+"safras" de pioneiros da comunidade Ubuntu Brasil!
 
 Durante nosso bate-papo o Fábio conta como que sua participação nesta
 comunidade começou no finalzinho de 2005, ao pedir ajuda com certas
@@ -57,7 +54,7 @@ Escute Agora
 
 Contato
 -------
--  **Blog**: `http://blog.fnogueira.com.br <http://blog.fnogueira.com.br/>`__
+-  **Blog**: `http://blog.fnogueira.com.br`_
 -  **Twitter**:  https://twitter.com/Ubuntuser
 -  **Facebook**:  https://www.facebook.com/ubuntuser
 -  **Google+**:  https://plus.google.com/u/1/113268886471244843047
@@ -82,44 +79,44 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Elvis Presley <http://www.last.fm/search?q=Elvis+Presley>`__
--  **Música:** `Johnny Cash <http://www.last.fm/search?q=Johnny+Cash>`__
--  **Música:** `Bee Gees <http://www.last.fm/search?q=Bee+Gees>`__
--  **Música:** `Black Sabath <http://www.last.fm/search?q=Black+Sabath>`__
--  **Música:** `Deep Purple <http://www.last.fm/search?q=Deep+Purple>`__
--  **Filmes:** `De volta para o futuro <http://www.imdb.com/find?s=all&q=De+volta+para+o+futuro>`__
--  **Filmes:** `Círculo de fogo <http://www.imdb.com/find?s=all&q=Círculo+de+fogo>`__
--  **Livros:** `Stalingrado Cerco Fatal <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Stalingrado+Cerco+Fatal>`__
--  **Livros:** `Portões de Fogo <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Portões+de+Fogo>`__
--  **Livros:** `Jorge Amado <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Jorge+Amado>`__
+-  **Música:** `Elvis Presley`_
+-  **Música:** `Johnny Cash`_
+-  **Música:** `Bee Gees`_
+-  **Música:** `Black Sabath`_
+-  **Música:** `Deep Purple`_
+-  **Filmes:** `De volta para o futuro`_
+-  **Filmes:** `Círculo de fogo`_
+-  **Livros:** `Stalingrado Cerco Fatal`_
+-  **Livros:** `Portões de Fogo`_
+-  **Livros:** `Jorge Amado`_
 
 Links
 -----
--  `Ubuntu Brasil <https://duckduckgo.com/?q=Ubuntu+Brasil>`__
--  `Kalango Linux <https://duckduckgo.com/?q=Kalango+Linux>`__
--  `Ubuntu Linux <https://duckduckgo.com/?q=Ubuntu+Linux>`__
--  `Emerson Soares <https://duckduckgo.com/?q=Emerson+Soares>`__
--  `Raphael Higino <https://duckduckgo.com/?q=Raphael+Higino>`__
--  `Projeto GNOME <https://duckduckgo.com/?q=Projeto+GNOME>`__
--  `Chave GPG <https://duckduckgo.com/?q=Chave+GPG>`__
--  `Mário Meyer <https://duckduckgo.com/?q=Mário+Meyer>`__
--  `Paulino Michelazzo <https://duckduckgo.com/?q=Paulino+Michelazzo>`__
--  `Rodrigo Belém <https://duckduckgo.com/?q=Rodrigo+Belém>`__
--  `Planeta Ubuntu Brasil <https://duckduckgo.com/?q=Planeta+Ubuntu+Brasil>`__
--  `Ian Laurence <https://duckduckgo.com/?q=Ian+Laurence>`__
--  `Lício Fonseca <https://duckduckgo.com/?q=Lício+Fonseca>`__
--  `Duda Nogueira <https://duckduckgo.com/?q=Duda+Nogueira>`__
--  `Jonh Wendell <https://duckduckgo.com/?q=Jonh+Wendell>`__
--  `André Noel <https://duckduckgo.com/?q=André+Noel>`__
--  `Ricardo Cropalato <https://duckduckgo.com/?q=Ricardo+Cropalato>`__
--  `Alexandre Silva <https://duckduckgo.com/?q=Alexandre+Silva>`__
--  `Ubuntu Bahía <https://duckduckgo.com/?q=Ubuntu+Bahía>`__
--  `André Gondim <https://duckduckgo.com/?q=André+Gondim>`__
--  `Thiago Hillebrandt <https://duckduckgo.com/?q=Thiago+Hillebrandt>`__
--  `Ayrton Araújo <https://duckduckgo.com/?q=Ayrton+Araújo>`__
--  `Canonical <https://duckduckgo.com/?q=Canonical>`__
--  `Elvis Presley <https://duckduckgo.com/?q=Elvis+Presley>`__
--  `Coringão <https://duckduckgo.com/?q=Coringão>`__
+-  `Ubuntu Brasil`_
+-  `Kalango Linux`_
+-  `Ubuntu Linux`_
+-  `Emerson Soares`_
+-  `Raphael Higino`_
+-  `Projeto GNOME`_
+-  `Chave GPG`_
+-  `Mário Meyer`_
+-  `Paulino Michelazzo`_
+-  `Rodrigo Belém (DuckDuckGo)`_
+-  `Planeta Ubuntu Brasil`_
+-  `Ian Laurence`_
+-  `Lício Fonseca`_
+-  `Duda Nogueira`_
+-  `Jonh Wendell`_
+-  `André Noel`_
+-  `Ricardo Cropalato`_
+-  `Alexandre Silva`_
+-  `Ubuntu Bahía`_
+-  `André Gondim`_
+-  `Thiago Hillebrandt`_
+-  `Ayrton Araújo`_
+-  `Canonical`_
+-  `Elvis Presley (DuckDuckGo)`_
+-  `Coringão`_
 
 .. class:: panel-body bg-info
 
@@ -128,3 +125,41 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _vídeo: http://www.youtube.com/watch?v=Dgf8Bvn8tYI
+.. _Rodrigo Belém: http://www.castalio.info/rodrigo-belem-ubuntu-brasil/
+.. _http://blog.fnogueira.com.br: http://blog.fnogueira.com.br/
+.. _Elvis Presley: http://www.last.fm/search?q=Elvis+Presley
+.. _Johnny Cash: http://www.last.fm/search?q=Johnny+Cash
+.. _Bee Gees: http://www.last.fm/search?q=Bee+Gees
+.. _Black Sabath: http://www.last.fm/search?q=Black+Sabath
+.. _Deep Purple: http://www.last.fm/search?q=Deep+Purple
+.. _De volta para o futuro: http://www.imdb.com/find?s=all&q=De+volta+para+o+futuro
+.. _Círculo de fogo: http://www.imdb.com/find?s=all&q=Círculo+de+fogo
+.. _Stalingrado Cerco Fatal: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Stalingrado+Cerco+Fatal
+.. _Portões de Fogo: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Portões+de+Fogo
+.. _Jorge Amado: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Jorge+Amado
+.. _Ubuntu Brasil: https://duckduckgo.com/?q=Ubuntu+Brasil
+.. _Kalango Linux: https://duckduckgo.com/?q=Kalango+Linux
+.. _Ubuntu Linux: https://duckduckgo.com/?q=Ubuntu+Linux
+.. _Emerson Soares: https://duckduckgo.com/?q=Emerson+Soares
+.. _Raphael Higino: https://duckduckgo.com/?q=Raphael+Higino
+.. _Projeto GNOME: https://duckduckgo.com/?q=Projeto+GNOME
+.. _Chave GPG: https://duckduckgo.com/?q=Chave+GPG
+.. _Mário Meyer: https://duckduckgo.com/?q=Mário+Meyer
+.. _Paulino Michelazzo: https://duckduckgo.com/?q=Paulino+Michelazzo
+.. _Rodrigo Belém (DuckDuckGo): https://duckduckgo.com/?q=Rodrigo+Belém
+.. _Planeta Ubuntu Brasil: https://duckduckgo.com/?q=Planeta+Ubuntu+Brasil
+.. _Ian Laurence: https://duckduckgo.com/?q=Ian+Laurence
+.. _Lício Fonseca: https://duckduckgo.com/?q=Lício+Fonseca
+.. _Duda Nogueira: https://duckduckgo.com/?q=Duda+Nogueira
+.. _Jonh Wendell: https://duckduckgo.com/?q=Jonh+Wendell
+.. _André Noel: https://duckduckgo.com/?q=André+Noel
+.. _Ricardo Cropalato: https://duckduckgo.com/?q=Ricardo+Cropalato
+.. _Alexandre Silva: https://duckduckgo.com/?q=Alexandre+Silva
+.. _Ubuntu Bahía: https://duckduckgo.com/?q=Ubuntu+Bahía
+.. _André Gondim: https://duckduckgo.com/?q=André+Gondim
+.. _Thiago Hillebrandt: https://duckduckgo.com/?q=Thiago+Hillebrandt
+.. _Ayrton Araújo: https://duckduckgo.com/?q=Ayrton+Araújo
+.. _Canonical: https://duckduckgo.com/?q=Canonical
+.. _Elvis Presley (DuckDuckGo): https://duckduckgo.com/?q=Elvis+Presley
+.. _Coringão: https://duckduckgo.com/?q=Coringão

--- a/content/episodes/042-cristiano-costa-hora-do-mac.rst
+++ b/content/episodes/042-cristiano-costa-hora-do-mac.rst
@@ -12,14 +12,12 @@ Cristiano Costa: Hora do Mac
    Cristiano Costa: Hora do Mac
 
 **Atualização**: Me esqueci novamente de colocar o link para o vídeo da
-entrevista: `Youtube
-<http://www.youtube.com/watch?v=k58aVfWhIWE&feature=g-upl>`__
+entrevista: `Youtube`_
 
-Mais um dia de calor aqui na **Carolina do Norte**, e mesmo na correria
-desta semana eu consegui achar um pouco de tempo para entrevistar o
-**Cristiano Costa**, aka `@caccac <http://twitter.com/#!/caccac>`__, do podcast `Hora do
-Mac <http://www.horadomac.com/>`__ (**HDM**)! Quem ainda não conhece o
-**HDM** não sabe o que está perdendo!
+Mais um dia de calor aqui na **Carolina do Norte**, e mesmo na correria desta
+semana eu consegui achar um pouco de tempo para entrevistar o **Cristiano
+Costa**, aka `@caccac`_, do podcast `Hora do Mac`_ (**HDM**)! Quem ainda não
+conhece o **HDM** não sabe o que está perdendo!
 
 O **HDM** começou à quase 4 anos no fimzinho de 2008 lá em **Porto
 Alegre** e desde então o podcast já publicou **82 episódios** e só tem
@@ -69,49 +67,49 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Sex Pistols <http://www.last.fm/search?q=Sex+Pistols>`__
--  **Música:** `Dead Kennedys <http://www.last.fm/search?q=Dead+Kennedys>`__
--  **Música:** `U2 <http://www.last.fm/search?q=U2>`__
--  **Música:** `R.E.M. <http://www.last.fm/search?q=R.E.M.>`__
--  **Música:** `Norah Jones <http://www.last.fm/search?q=Norah+Jones>`__
--  **Música:** `Madeleine Peyroux <http://www.last.fm/search?q=Madeleine+Peyroux>`__
--  **Música:** `Carla Bruni <http://www.last.fm/search?q=Carla+Bruni>`__
--  **Música:** `Jorge Ben <http://www.last.fm/search?q=Jorge+Ben>`__
--  **Música:** `The Beatles <http://www.last.fm/search?q=The+Beatles>`__
--  **Filmes:** `House <http://www.imdb.com/find?s=all&q=House>`__
--  **Filmes:** `Breaking Bad <http://www.imdb.com/find?s=all&q=Breaking+Bad>`__
--  **Filmes:** `Two and a Half Man <http://www.imdb.com/find?s=all&q=Two+and+a+Half+Man>`__
--  **Filmes:** `Game of Thrones <http://www.imdb.com/find?s=all&q=Game+of+Thrones>`__
--  **Livros:** `John Sandford <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=John+Sandford>`__
--  **Livros:** `Michael Connelly <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Michael+Connelly>`__
--  **Livros:** `David Baldacci <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=David+Baldacci>`__
--  **Livros:** `Steve Jobs <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Steve+Jobs>`__
--  **Livros:** `Albert Einstein <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Albert+Einstein>`__
--  **Livros:** `Jeffrey Archer <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Jeffrey+Archer>`__
--  **Livros:** `Airton Ortiz <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Airton+Ortiz>`__
+-  **Música:** `Sex Pistols`_
+-  **Música:** `Dead Kennedys`_
+-  **Música:** `U2`_
+-  **Música:** `R.E.M.`_
+-  **Música:** `Norah Jones`_
+-  **Música:** `Madeleine Peyroux`_
+-  **Música:** `Carla Bruni`_
+-  **Música:** `Jorge Ben`_
+-  **Música:** `The Beatles`_
+-  **Filmes:** `House`_
+-  **Filmes:** `Breaking Bad`_
+-  **Filmes:** `Two and a Half Man`_
+-  **Filmes:** `Game of Thrones`_
+-  **Livros:** `John Sandford`_
+-  **Livros:** `Michael Connelly`_
+-  **Livros:** `David Baldacci`_
+-  **Livros:** `Steve Jobs`_
+-  **Livros:** `Albert Einstein`_
+-  **Livros:** `Jeffrey Archer`_
+-  **Livros:** `Airton Ortiz`_
 
 Links
 -----
--  `Leo Laporte <https://duckduckgo.com/?q=Leo+Laporte>`__
--  `MacBreak Weekly <https://duckduckgo.com/?q=MacBreak+Weekly>`__
--  `Computadores Apple <https://duckduckgo.com/?q=Computadores+Apple>`__
--  `iPhone <https://duckduckgo.com/?q=iPhone>`__
--  `Skype <https://duckduckgo.com/?q=Skype>`__
--  `Google Hangout <https://duckduckgo.com/?q=Google+Hangout>`__
--  `WordPress <https://duckduckgo.com/?q=WordPress>`__
--  `iTunes <https://duckduckgo.com/?q=iTunes>`__
--  `Hora do Mac <https://duckduckgo.com/?q=Hora+do+Mac>`__
--  `FISL <https://duckduckgo.com/?q=FISL>`__
--  `Kit Inicial de Podcasts <https://duckduckgo.com/?q=Kit+Inicial+de+Podcasts>`__
--  `Plataforma Android <https://duckduckgo.com/?q=Plataforma+Android>`__
--  `Plataforma iOS <https://duckduckgo.com/?q=Plataforma+iOS>`__
--  `Unix <https://duckduckgo.com/?q=Unix>`__
--  `Acqua <https://duckduckgo.com/?q=Acqua>`__
--  `Windows 8 <https://duckduckgo.com/?q=Windows+8>`__
--  `Amazon Prime <https://duckduckgo.com/?q=Amazon+Prime>`__
--  `Rdio <https://duckduckgo.com/?q=Rdio>`__
--  `Netflix <https://duckduckgo.com/?q=Netflix>`__
--  `Amyr Klink <https://duckduckgo.com/?q=Amyr+Klink>`__
+-  `Leo Laporte`_
+-  `MacBreak Weekly`_
+-  `Computadores Apple`_
+-  `iPhone`_
+-  `Skype`_
+-  `Google Hangout`_
+-  `WordPress`_
+-  `iTunes`_
+-  `Hora do Mac (DuckDuckGo)`_
+-  `FISL`_
+-  `Kit Inicial de Podcasts`_
+-  `Plataforma Android`_
+-  `Plataforma iOS`_
+-  `Unix`_
+-  `Acqua`_
+-  `Windows 8`_
+-  `Amazon Prime`_
+-  `Rdio`_
+-  `Netflix`_
+-  `Amyr Klink`_
 
 .. class:: panel-body bg-info
 
@@ -120,3 +118,46 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _Youtube: http://www.youtube.com/watch?v=k58aVfWhIWE&feature=g-upl
+.. _@caccac: http://twitter.com/#!/caccac
+.. _Sex Pistols: http://www.last.fm/search?q=Sex+Pistols
+.. _Dead Kennedys: http://www.last.fm/search?q=Dead+Kennedys
+.. _U2: http://www.last.fm/search?q=U2
+.. _R.E.M.: http://www.last.fm/search?q=R.E.M.
+.. _Norah Jones: http://www.last.fm/search?q=Norah+Jones
+.. _Madeleine Peyroux: http://www.last.fm/search?q=Madeleine+Peyroux
+.. _Carla Bruni: http://www.last.fm/search?q=Carla+Bruni
+.. _Jorge Ben: http://www.last.fm/search?q=Jorge+Ben
+.. _The Beatles: http://www.last.fm/search?q=The+Beatles
+.. _House: http://www.imdb.com/find?s=all&q=House
+.. _Breaking Bad: http://www.imdb.com/find?s=all&q=Breaking+Bad
+.. _Two and a Half Man: http://www.imdb.com/find?s=all&q=Two+and+a+Half+Man
+.. _Game of Thrones: http://www.imdb.com/find?s=all&q=Game+of+Thrones
+.. _John Sandford: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=John+Sandford
+.. _Michael Connelly: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Michael+Connelly
+.. _David Baldacci: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=David+Baldacci
+.. _Steve Jobs: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Steve+Jobs
+.. _Albert Einstein: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Albert+Einstein
+.. _Jeffrey Archer: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Jeffrey+Archer
+.. _Airton Ortiz: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Airton+Ortiz
+.. _Leo Laporte: https://duckduckgo.com/?q=Leo+Laporte
+.. _MacBreak Weekly: https://duckduckgo.com/?q=MacBreak+Weekly
+.. _Computadores Apple: https://duckduckgo.com/?q=Computadores+Apple
+.. _iPhone: https://duckduckgo.com/?q=iPhone
+.. _Skype: https://duckduckgo.com/?q=Skype
+.. _Google Hangout: https://duckduckgo.com/?q=Google+Hangout
+.. _WordPress: https://duckduckgo.com/?q=WordPress
+.. _iTunes: https://duckduckgo.com/?q=iTunes
+.. _Hora do Mac (DuckDuckGo): https://duckduckgo.com/?q=Hora+do+Mac
+.. _FISL: https://duckduckgo.com/?q=FISL
+.. _Kit Inicial de Podcasts: https://duckduckgo.com/?q=Kit+Inicial+de+Podcasts
+.. _Plataforma Android: https://duckduckgo.com/?q=Plataforma+Android
+.. _Plataforma iOS: https://duckduckgo.com/?q=Plataforma+iOS
+.. _Unix: https://duckduckgo.com/?q=Unix
+.. _Acqua: https://duckduckgo.com/?q=Acqua
+.. _Windows 8: https://duckduckgo.com/?q=Windows+8
+.. _Amazon Prime: https://duckduckgo.com/?q=Amazon+Prime
+.. _Rdio: https://duckduckgo.com/?q=Rdio
+.. _Netflix: https://duckduckgo.com/?q=Netflix
+.. _Amyr Klink: https://duckduckgo.com/?q=Amyr+Klink
+.. _Hora do Mac: http://www.horadomac.com/

--- a/content/episodes/043-felipe-borges-google-summer-of-code.rst
+++ b/content/episodes/043-felipe-borges-google-summer-of-code.rst
@@ -11,10 +11,9 @@ Felipe Borges: Google Summer of Code
 
    Felipe Borges
 
-Finalzinho do verão americano e no ar já se sente um pouco a vinda do
-outono e a volta às aulas. Nada melhor então que bater um papo com o
-**Felipe Borges** que está participando do `Google Summer of
-Code <https://code.google.com/soc/>`__ pelo projeto **GNOME**!
+Finalzinho do verão americano e no ar já se sente um pouco a vinda do outono
+e a volta às aulas. Nada melhor então que bater um papo com o **Felipe Borges**
+que está participando do `Google Summer of Code`_ pelo projeto **GNOME**!
 
 Durante estes últimos meses o Felipe tem trabalhado no **GNOME
 Documents**, adicionando suporte para administrar e visualizar arquivos
@@ -33,9 +32,8 @@ conta com várias surpresas bem interessantes! Mal posso esperar o dia
 quando vou poder bater altos papos com o Felipe sobre política e
 assuntos diversos... quem sabe no próximo **FISL**?
 
-Mais uma vez a gravação foi feita ao vivo pelo **Youtube** e se você
-quizer assistir a entrevista, veja este
-`vídeo <http://www.youtube.com/watch?v=0T6nGDSr13o>`__.
+Mais uma vez a gravação foi feita ao vivo pelo **Youtube** e se você quizer
+assistir a entrevista, veja este `vídeo`_.
 
 Escute Agora
 ------------
@@ -69,57 +67,57 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Immortal Technique <http://www.last.fm/search?q=Immortal+Technique>`__
--  **Música:** `Criolo <http://www.last.fm/search?q=Criolo>`__
--  **Música:** `Bob Marley <http://www.last.fm/search?q=Bob+Marley>`__
--  **Música:** `Cavalera Conspiracy <http://www.last.fm/search?q=Cavalera+Conspiracy>`__
--  **Música:** `Lowkey <http://www.last.fm/search?q=Lowkey>`__
--  **Filmes:** `Prison Break <http://www.imdb.com/find?s=all&q=Prison+Break>`__
--  **Filmes:** `Big Bang Theory <http://www.imdb.com/find?s=all&q=Big+Bang+Theory>`__
--  **Filmes:** `The IT Crowd <http://www.imdb.com/find?s=all&q=The+IT+Crowd>`__
--  **Filmes:** `Chavez <http://www.imdb.com/find?s=all&q=Chavez>`__
--  **Filmes:** `Homeland <http://www.imdb.com/find?s=all&q=Homeland>`__
--  **Livros:** `Pablo Neruda <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Pablo+Neruda>`__
--  **Livros:** `Cidade do Sol <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Cidade+do+Sol>`__
--  **Livros:** `Khaled Hossein <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Khaled+Hossein>`__
--  **Livros:** `Os Sertões <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Os+Sertões>`__
--  **Livros:** `Euclydes da Cunha <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Euclydes+da+Cunha>`__
--  **Livros:** `Batalha do Apocalipse <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Batalha+do+Apocalipse>`__
--  **Livros:** `Eduardo Spohr <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Eduardo+Spohr>`__
--  **Livros:** `Design for Hackers <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Design+for+Hackers>`__
--  **Livros:** `Eduardo Galeano <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Eduardo+Galeano>`__
+-  **Música:** `Immortal Technique`_
+-  **Música:** `Criolo`_
+-  **Música:** `Bob Marley`_
+-  **Música:** `Cavalera Conspiracy`_
+-  **Música:** `Lowkey`_
+-  **Filmes:** `Prison Break`_
+-  **Filmes:** `Big Bang Theory`_
+-  **Filmes:** `The IT Crowd`_
+-  **Filmes:** `Chavez`_
+-  **Filmes:** `Homeland`_
+-  **Livros:** `Pablo Neruda`_
+-  **Livros:** `Cidade do Sol`_
+-  **Livros:** `Khaled Hossein`_
+-  **Livros:** `Os Sertões`_
+-  **Livros:** `Euclydes da Cunha`_
+-  **Livros:** `Batalha do Apocalipse`_
+-  **Livros:** `Eduardo Spohr`_
+-  **Livros:** `Design for Hackers`_
+-  **Livros:** `Eduardo Galeano`_
 
 Links
 -----
--  `Planet GNOME <https://duckduckgo.com/?q=Planet+GNOME>`__
--  `Universidade Federal de Pelotas <https://duckduckgo.com/?q=Universidade+Federal+de+Pelotas>`__
--  `Projeto GNOME <https://duckduckgo.com/?q=Projeto+GNOME>`__
--  `FISL <https://duckduckgo.com/?q=FISL>`__
--  `Fundação GNOME <https://duckduckgo.com/?q=Fundação+GNOME>`__
--  `Fundação Mozilla <https://duckduckgo.com/?q=Fundação+Mozilla>`__
--  `Bugzilla <https://duckduckgo.com/?q=Bugzilla>`__
--  `GNOME Documents <https://duckduckgo.com/?q=GNOME+Documents>`__
--  `Microsoft SkyDrive <https://duckduckgo.com/?q=Microsoft+SkyDrive>`__
--  `GIO <https://duckduckgo.com/?q=GIO>`__
--  `Tracker <https://duckduckgo.com/?q=Tracker>`__
--  `Nokia <https://duckduckgo.com/?q=Nokia>`__
--  `Cosimo Cecchi <https://duckduckgo.com/?q=Cosimo+Cecchi>`__
--  `Github <https://duckduckgo.com/?q=Github>`__
--  `GUADEC <https://duckduckgo.com/?q=GUADEC>`__
--  `Programação em C <https://duckduckgo.com/?q=Programação+em+C>`__
--  `Javascript <https://duckduckgo.com/?q=Javascript>`__
--  `Programação em Python <https://duckduckgo.com/?q=Programação+em+Python>`__
--  `GLIB <https://duckduckgo.com/?q=GLIB>`__
--  `Evince <https://duckduckgo.com/?q=Evince>`__
--  `Biblioteca libevince <https://duckduckgo.com/?q=Biblioteca+libevince>`__
--  `Formato epub <https://duckduckgo.com/?q=Formato+epub>`__
--  `Formato mobi <https://duckduckgo.com/?q=Formato+mobi>`__
--  `Amazon <https://duckduckgo.com/?q=Amazon>`__
--  `Sepultura <https://duckduckgo.com/?q=Sepultura>`__
--  `Walt Disney <https://duckduckgo.com/?q=Walt+Disney>`__
--  `Red Hat <https://duckduckgo.com/?q=Red+Hat>`__
--  `Djavan Fagundes <https://duckduckgo.com/?q=Djavan+Fagundes>`__
--  `iTunes <https://duckduckgo.com/?q=iTunes>`__
+-  `Planet GNOME`_
+-  `Universidade Federal de Pelotas`_
+-  `Projeto GNOME`_
+-  `FISL`_
+-  `Fundação GNOME`_
+-  `Fundação Mozilla`_
+-  `Bugzilla`_
+-  `GNOME Documents`_
+-  `Microsoft SkyDrive`_
+-  `GIO`_
+-  `Tracker`_
+-  `Nokia`_
+-  `Cosimo Cecchi`_
+-  `Github`_
+-  `GUADEC`_
+-  `Programação em C`_
+-  `Javascript`_
+-  `Programação em Python`_
+-  `GLIB`_
+-  `Evince`_
+-  `Biblioteca libevince`_
+-  `Formato epub`_
+-  `Formato mobi`_
+-  `Amazon`_
+-  `Sepultura`_
+-  `Walt Disney`_
+-  `Red Hat`_
+-  `Djavan Fagundes`_
+-  `iTunes`_
 
 .. class:: panel-body bg-info
 
@@ -128,3 +126,53 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _Google Summer of Code: https://code.google.com/soc/
+.. _vídeo: http://www.youtube.com/watch?v=0T6nGDSr13o
+.. _Immortal Technique: http://www.last.fm/search?q=Immortal+Technique
+.. _Criolo: http://www.last.fm/search?q=Criolo
+.. _Bob Marley: http://www.last.fm/search?q=Bob+Marley
+.. _Cavalera Conspiracy: http://www.last.fm/search?q=Cavalera+Conspiracy
+.. _Lowkey: http://www.last.fm/search?q=Lowkey
+.. _Prison Break: http://www.imdb.com/find?s=all&q=Prison+Break
+.. _Big Bang Theory: http://www.imdb.com/find?s=all&q=Big+Bang+Theory
+.. _The IT Crowd: http://www.imdb.com/find?s=all&q=The+IT+Crowd
+.. _Chavez: http://www.imdb.com/find?s=all&q=Chavez
+.. _Homeland: http://www.imdb.com/find?s=all&q=Homeland
+.. _Pablo Neruda: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Pablo+Neruda
+.. _Cidade do Sol: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Cidade+do+Sol
+.. _Khaled Hossein: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Khaled+Hossein
+.. _Os Sertões: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Os+Sertões
+.. _Euclydes da Cunha: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Euclydes+da+Cunha
+.. _Batalha do Apocalipse: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Batalha+do+Apocalipse
+.. _Eduardo Spohr: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Eduardo+Spohr
+.. _Design for Hackers: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Design+for+Hackers
+.. _Eduardo Galeano: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Eduardo+Galeano
+.. _Planet GNOME: https://duckduckgo.com/?q=Planet+GNOME
+.. _Universidade Federal de Pelotas: https://duckduckgo.com/?q=Universidade+Federal+de+Pelotas
+.. _Projeto GNOME: https://duckduckgo.com/?q=Projeto+GNOME
+.. _FISL: https://duckduckgo.com/?q=FISL
+.. _Fundação GNOME: https://duckduckgo.com/?q=Fundação+GNOME
+.. _Fundação Mozilla: https://duckduckgo.com/?q=Fundação+Mozilla
+.. _Bugzilla: https://duckduckgo.com/?q=Bugzilla
+.. _GNOME Documents: https://duckduckgo.com/?q=GNOME+Documents
+.. _Microsoft SkyDrive: https://duckduckgo.com/?q=Microsoft+SkyDrive
+.. _GIO: https://duckduckgo.com/?q=GIO
+.. _Tracker: https://duckduckgo.com/?q=Tracker
+.. _Nokia: https://duckduckgo.com/?q=Nokia
+.. _Cosimo Cecchi: https://duckduckgo.com/?q=Cosimo+Cecchi
+.. _Github: https://duckduckgo.com/?q=Github
+.. _GUADEC: https://duckduckgo.com/?q=GUADEC
+.. _Programação em C: https://duckduckgo.com/?q=Programação+em+C
+.. _Javascript: https://duckduckgo.com/?q=Javascript
+.. _Programação em Python: https://duckduckgo.com/?q=Programação+em+Python
+.. _GLIB: https://duckduckgo.com/?q=GLIB
+.. _Evince: https://duckduckgo.com/?q=Evince
+.. _Biblioteca libevince: https://duckduckgo.com/?q=Biblioteca+libevince
+.. _Formato epub: https://duckduckgo.com/?q=Formato+epub
+.. _Formato mobi: https://duckduckgo.com/?q=Formato+mobi
+.. _Amazon: https://duckduckgo.com/?q=Amazon
+.. _Sepultura: https://duckduckgo.com/?q=Sepultura
+.. _Walt Disney: https://duckduckgo.com/?q=Walt+Disney
+.. _Red Hat: https://duckduckgo.com/?q=Red+Hat
+.. _Djavan Fagundes: https://duckduckgo.com/?q=Djavan+Fagundes
+.. _iTunes: https://duckduckgo.com/?q=iTunes

--- a/content/episodes/044-bruno-goncalves-biglinux.rst
+++ b/content/episodes/044-bruno-goncalves-biglinux.rst
@@ -13,44 +13,35 @@ Bruno Gonçalves: BigLinux
 
    Bruno Gonçalves: BigLinux
 
-Na semana passada eu tive o grande prazer e honra de participar do
-`Opencast <http://www.ubuntero.com.br/>`__ em um
-`episódio <http://www.ubuntero.com.br/2012/08/opencast-16-distribuicoes-linux/>`__
-onde discutimos várias coisas relacionadas à distribuições Linux! Por
-coincidência, meu amigo **Vladimir Melo** tinha me recomendando
+Na semana passada eu tive o grande prazer e honra de participar do `Opencast`_
+em um `episódio`_ onde discutimos várias coisas relacionadas à distribuições
+Linux! Por coincidência, meu amigo **Vladimir Melo** tinha me recomendando
 entrevistar uma pessoa que por muito tempo tinha criado e mantido uma
 distribuição nacional, e recentemente decidiu parar o projeto!
 
-Neste último episódio então tive o grande prazer de conversar com o
-**Bruno Gonçalves**, criador e mantenedor do
-`BigLinux <http://www.biglinux.com.br/web/>`__! Até este nosso bate-papo
-eu confesso que não conhecia este projeto, o que é realmente uma pena. O
-BigLinux nasceu de uma "remasterização" do `Kurumin
-Linux <http://www.hardware.com.br/kurumin/>`__ e em pouquíssimo tempo
-fez bastante barulho ao adicionar vários recursos super avançados para a
-sua época! O número de recursos e tecnologias utilizados pelo Bruno é
-realmente impressionante e quando terminamos nossa entrevista eu fiquei
-literalmente fã número 1 dele! :)
+Neste último episódio então tive o grande prazer de conversar com o **Bruno
+Gonçalves**, criador e mantenedor do `BigLinux`_! Até este nosso bate-papo eu
+confesso que não conhecia este projeto, o que é realmente uma pena. O BigLinux
+nasceu de uma "remasterização" do `Kurumin Linux`_ e em pouquíssimo tempo fez
+bastante barulho ao adicionar vários recursos super avançados para a sua época!
+O número de recursos e tecnologias utilizados pelo Bruno é realmente
+impressionante e quando terminamos nossa entrevista eu fiquei literalmente fã
+número 1 dele! :)
 
-Durante nosso bate-papo ele conta todos os detalhes de como que o
-projeto nasceu, quais foram os obstáculos que enfrentou, e quais foram
-os motivos que o levou a parar o projeto. Também falamos sobre
-**BigBashView**, seu novo projeto \ `União
-Livre <http://uniaolivre.com/>`__, que na minha opinião promete muito, e
-um **livro** que esta escrevendo em parceria com um amigo, chamado
-"**Linux: Simplicidade ao seu Alcance**\ "!
+Durante nosso bate-papo ele conta todos os detalhes de como que o projeto
+nasceu, quais foram os obstáculos que enfrentou, e quais foram os motivos que
+o levou a parar o projeto. Também falamos sobre **BigBashView**, seu novo
+projeto \ `União Livre`_, que na minha opinião promete muito, e um **livro**
+que esta escrevendo em parceria com um amigo, chamado "**Linux: Simplicidade ao
+seu Alcance**\ "!
 
 .. more
 
-Quem quizer experimentar o BigLinux, dê uma olhadinha no seguinte
-`link <http://www.las.ic.unicamp.br/pub/biglinux/>`__ para algumas
-imagens ISO e se você quizer aprender mais sobre o
-`BigBashLinux <http://code.google.com/p/bigbashview/>`__, olhem este
-link `aqui <http://biglinux.com.br/forum/viewforum.php?f=62>`__!
+Quem quizer experimentar o BigLinux, dê uma olhadinha no seguinte `link`_ para
+algumas imagens ISO e se você quizer aprender mais sobre o `BigBashLinux`_,
+olhem este link `aqui`_!
 
-Ah e não se esqueca de assistir o
-`vídeo <http://www.youtube.com/watch?v=lpDNGGOw_tY&feature=g-all-u>`__
-da entrevista!
+Ah e não se esqueca de assistir o `vídeo`_ da entrevista!
 
 Escute Agora
 ------------
@@ -83,59 +74,59 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Raul Seixas <http://www.last.fm/search?q=Raul+Seixas>`__
--  **Música:** `Ultrage a Rigor <http://www.last.fm/search?q=Ultrage+a+Rigor>`__
--  **Música:** `Chuck Berry <http://www.last.fm/search?q=Chuck+Berry>`__
--  **Música:** `Elvis Presley <http://www.last.fm/search?q=Elvis+Presley>`__
--  **Música:** `Planet Hemp <http://www.last.fm/search?q=Planet+Hemp>`__
--  **Música:** `Frejat <http://www.last.fm/search?q=Frejat>`__
--  **Filmes:** `Rocky <http://www.imdb.com/find?s=all&q=Rocky>`__
--  **Filmes:** `Scarface <http://www.imdb.com/find?s=all&q=Scarface>`__
--  **Filmes:** `Chavez <http://www.imdb.com/find?s=all&q=Chavez>`__
--  **Filmes:** `Chapolin <http://www.imdb.com/find?s=all&q=Chapolin>`__
--  **Filmes:** `O Grande Dragão Branco <http://www.imdb.com/find?s=all&q=O+Grande+Dragão+Branco>`__
--  **Livros:** `Fórum BigLinux <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Fórum+BigLinux>`__
--  **Livros:** `Fórum Ubuntu BR <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Fórum+Ubuntu+BR>`__
--  **Livros:** `Fórum Outer Space <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Fórum+Outer+Space>`__
--  **Livros:** `Fórum Hard Science <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Fórum+Hard+Science>`__
--  **Livros:** `BR-Linux <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=BR-Linux>`__
--  **Livros:** `Forum nix <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Forum+nix>`__
--  **Livros:** `Planet KDE <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Planet+KDE>`__
+-  **Música:** `Raul Seixas`_
+-  **Música:** `Ultrage a Rigor`_
+-  **Música:** `Chuck Berry`_
+-  **Música:** `Elvis Presley`_
+-  **Música:** `Planet Hemp`_
+-  **Música:** `Frejat`_
+-  **Filmes:** `Rocky`_
+-  **Filmes:** `Scarface`_
+-  **Filmes:** `Chavez`_
+-  **Filmes:** `Chapolin`_
+-  **Filmes:** `O Grande Dragão Branco`_
+-  **Livros:** `Fórum BigLinux`_
+-  **Livros:** `Fórum Ubuntu BR`_
+-  **Livros:** `Fórum Outer Space`_
+-  **Livros:** `Fórum Hard Science`_
+-  **Livros:** `BR-Linux`_
+-  **Livros:** `Forum nix`_
+-  **Livros:** `Planet KDE`_
 
 Links
 -----
--  `Vladimir Melo <https://duckduckgo.com/?q=Vladimir+Melo>`__
--  `BigLinux <https://duckduckgo.com/?q=BigLinux>`__
--  `Bruno Gonçalves <https://duckduckgo.com/?q=Bruno+Gonçalves>`__
--  `Kurumin Linux <https://duckduckgo.com/?q=Kurumin+Linux>`__
--  `OpenOffice <https://duckduckgo.com/?q=OpenOffice>`__
--  `Gimp <https://duckduckgo.com/?q=Gimp>`__
--  `ICQ <https://duckduckgo.com/?q=ICQ>`__
--  `Kalango Linux <https://duckduckgo.com/?q=Kalango+Linux>`__
--  `Debian Linux <https://duckduckgo.com/?q=Debian+Linux>`__
--  `KDE <https://duckduckgo.com/?q=KDE>`__
--  `GNOME <https://duckduckgo.com/?q=GNOME>`__
--  `Metisse <https://duckduckgo.com/?q=Metisse>`__
--  `Fluxbox <https://duckduckgo.com/?q=Fluxbox>`__
--  `Mark Shuttleworth <https://duckduckgo.com/?q=Mark+Shuttleworth>`__
--  `Compiz <https://duckduckgo.com/?q=Compiz>`__
--  `Ubuntu Linux <https://duckduckgo.com/?q=Ubuntu+Linux>`__
--  `Carlos Morimoto <https://duckduckgo.com/?q=Carlos+Morimoto>`__
--  `IceWM <https://duckduckgo.com/?q=IceWM>`__
--  `Gnumeric <https://duckduckgo.com/?q=Gnumeric>`__
--  `Python <https://duckduckgo.com/?q=Python>`__
--  `BigBashView <https://duckduckgo.com/?q=BigBashView>`__
--  `QT Webkit <https://duckduckgo.com/?q=QT+Webkit>`__
--  `NVIDIA <https://duckduckgo.com/?q=NVIDIA>`__
--  `OpenCast <https://duckduckgo.com/?q=OpenCast>`__
--  `DistroWatch <https://duckduckgo.com/?q=DistroWatch>`__
--  `BR-Linux <https://duckduckgo.com/?q=BR-Linux>`__
--  `Conectiva Linux <https://duckduckgo.com/?q=Conectiva+Linux>`__
--  `União Livre <https://duckduckgo.com/?q=União+Livre>`__
--  `OpenSUSE Linux <https://duckduckgo.com/?q=OpenSUSE+Linux>`__
--  `Red Hat <https://duckduckgo.com/?q=Red+Hat>`__
--  `Canonical <https://duckduckgo.com/?q=Canonical>`__
--  `Mint Linux <https://duckduckgo.com/?q=Mint+Linux>`__
+-  `Vladimir Melo`_
+-  `BigLinux (DuckDuckGo)`_
+-  `Bruno Gonçalves`_
+-  `Kurumin Linux (DuckDuckGo)`_
+-  `OpenOffice`_
+-  `Gimp`_
+-  `ICQ`_
+-  `Kalango Linux`_
+-  `Debian Linux`_
+-  `KDE`_
+-  `GNOME`_
+-  `Metisse`_
+-  `Fluxbox`_
+-  `Mark Shuttleworth`_
+-  `Compiz`_
+-  `Ubuntu Linux`_
+-  `Carlos Morimoto`_
+-  `IceWM`_
+-  `Gnumeric`_
+-  `Python`_
+-  `BigBashView`_
+-  `QT Webkit`_
+-  `NVIDIA`_
+-  `OpenCast (DuckDuckGo)`_
+-  `DistroWatch`_
+-  `BR-Linux (DuckDuckGo)`_
+-  `Conectiva Linux`_
+-  `União Livre`_
+-  `OpenSUSE Linux`_
+-  `Red Hat`_
+-  `Canonical`_
+-  `Mint Linux`_
 
 .. class:: panel-body bg-info
 
@@ -144,3 +135,61 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _Opencast: http://www.ubuntero.com.br/
+.. _episódio: http://www.ubuntero.com.br/2012/08/opencast-16-distribuicoes-linux/
+.. _BigLinux: http://www.biglinux.com.br/web/
+.. _União Livre: http://uniaolivre.com/
+.. _link: http://www.las.ic.unicamp.br/pub/biglinux/
+.. _BigBashLinux: http://code.google.com/p/bigbashview/
+.. _aqui: http://biglinux.com.br/forum/viewforum.php?f=62
+.. _vídeo: http://www.youtube.com/watch?v=lpDNGGOw_tY&feature=g-all-u
+.. _Raul Seixas: http://www.last.fm/search?q=Raul+Seixas
+.. _Ultrage a Rigor: http://www.last.fm/search?q=Ultrage+a+Rigor
+.. _Chuck Berry: http://www.last.fm/search?q=Chuck+Berry
+.. _Elvis Presley: http://www.last.fm/search?q=Elvis+Presley
+.. _Planet Hemp: http://www.last.fm/search?q=Planet+Hemp
+.. _Frejat: http://www.last.fm/search?q=Frejat
+.. _Rocky: http://www.imdb.com/find?s=all&q=Rocky
+.. _Scarface: http://www.imdb.com/find?s=all&q=Scarface
+.. _Chavez: http://www.imdb.com/find?s=all&q=Chavez
+.. _Chapolin: http://www.imdb.com/find?s=all&q=Chapolin
+.. _O Grande Dragão Branco: http://www.imdb.com/find?s=all&q=O+Grande+Dragão+Branco
+.. _Fórum BigLinux: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Fórum+BigLinux
+.. _Fórum Ubuntu BR: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Fórum+Ubuntu+BR
+.. _Fórum Outer Space: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Fórum+Outer+Space
+.. _Fórum Hard Science: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Fórum+Hard+Science
+.. _BR-Linux: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=BR-Linux
+.. _Forum nix: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Forum+nix
+.. _Planet KDE: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Planet+KDE
+.. _Vladimir Melo: https://duckduckgo.com/?q=Vladimir+Melo
+.. _BigLinux (DuckDuckGo): https://duckduckgo.com/?q=BigLinux
+.. _Bruno Gonçalves: https://duckduckgo.com/?q=Bruno+Gonçalves
+.. _Kurumin Linux (DuckDuckGo): https://duckduckgo.com/?q=Kurumin+Linux
+.. _OpenOffice: https://duckduckgo.com/?q=OpenOffice
+.. _Gimp: https://duckduckgo.com/?q=Gimp
+.. _ICQ: https://duckduckgo.com/?q=ICQ
+.. _Kalango Linux: https://duckduckgo.com/?q=Kalango+Linux
+.. _Debian Linux: https://duckduckgo.com/?q=Debian+Linux
+.. _KDE: https://duckduckgo.com/?q=KDE
+.. _GNOME: https://duckduckgo.com/?q=GNOME
+.. _Metisse: https://duckduckgo.com/?q=Metisse
+.. _Fluxbox: https://duckduckgo.com/?q=Fluxbox
+.. _Mark Shuttleworth: https://duckduckgo.com/?q=Mark+Shuttleworth
+.. _Compiz: https://duckduckgo.com/?q=Compiz
+.. _Ubuntu Linux: https://duckduckgo.com/?q=Ubuntu+Linux
+.. _Carlos Morimoto: https://duckduckgo.com/?q=Carlos+Morimoto
+.. _IceWM: https://duckduckgo.com/?q=IceWM
+.. _Gnumeric: https://duckduckgo.com/?q=Gnumeric
+.. _Python: https://duckduckgo.com/?q=Python
+.. _BigBashView: https://duckduckgo.com/?q=BigBashView
+.. _QT Webkit: https://duckduckgo.com/?q=QT+Webkit
+.. _NVIDIA: https://duckduckgo.com/?q=NVIDIA
+.. _OpenCast (DuckDuckGo): https://duckduckgo.com/?q=OpenCast
+.. _DistroWatch: https://duckduckgo.com/?q=DistroWatch
+.. _BR-Linux (DuckDuckGo): https://duckduckgo.com/?q=BR-Linux
+.. _Conectiva Linux: https://duckduckgo.com/?q=Conectiva+Linux
+.. _OpenSUSE Linux: https://duckduckgo.com/?q=OpenSUSE+Linux
+.. _Red Hat: https://duckduckgo.com/?q=Red+Hat
+.. _Canonical: https://duckduckgo.com/?q=Canonical
+.. _Mint Linux: https://duckduckgo.com/?q=Mint+Linux
+.. _Kurumin Linux: http://www.hardware.com.br/kurumin/

--- a/content/episodes/045-licio-fonseca-google.rst
+++ b/content/episodes/045-licio-fonseca-google.rst
@@ -27,10 +27,9 @@ Também conversamos sobre as modificações que aconteceram na companhia
 desde que ele comçou a trabalhar, as viagens que ele fez à trabalho,
 rumores, sua **época de skatista**, vida de casado e coleção de action
 figures! E para quem acompanhou a gravação ao vivo pelo **Youtube**,
-teve até o Licio dançando a música `Gangnam
-Style <https://www.youtube.com/watch?v=9bZkp7q19f0>`__ do **PSY**!!! Mas
+teve até o Licio dançando a música `Gangnam Style`_ do **PSY**!!! Mas
 se você perdeu a gravação, não esquenta a cabeça porque o vídeo pode ser
-visto `aqui <http://bit.ly/QTNlg0>`__ (aos 41 minutos)! :)
+visto `aqui`_ (aos 41 minutos)! :)
 
 .. more
 
@@ -68,44 +67,44 @@ Resumo
 
 Top 5
 -----
--  **Música:** `Hugh Laurie <http://www.last.fm/search?q=Hugh+Laurie>`__
--  **Filmes:** `Novela <http://www.imdb.com/find?s=all&q=Novela>`__
--  **Filmes:** `Lisbela e o Prisioneiro <http://www.imdb.com/find?s=all&q=Lisbela+e+o+Prisioneiro>`__
--  **Filmes:** `Homem de Ferro <http://www.imdb.com/find?s=all&q=Homem+de+Ferro>`__
--  **Filmes:** `Batman <http://www.imdb.com/find?s=all&q=Batman>`__
--  **Filmes:** `Os Vingadores <http://www.imdb.com/find?s=all&q=Os+Vingadores>`__
--  **Livros:** `Longe é um lugar que não existe <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Longe+é+um+lugar+que+não+existe>`__
--  **Livros:** `Richard Bach <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Richard+Bach>`__
--  **Livros:** `Fernão Capelo Gaivota <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Fernão+Capelo+Gaivota>`__
--  **Livros:** `Para Gostar de Ler <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Para+Gostar+de+Ler>`__
--  **Livros:** `Carlos Drummond de Andrade <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Carlos+Drummond+de+Andrade>`__
--  **Livros:** `Ben Alves <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Ben+Alves>`__
--  **Livros:** `Fernando Sabino <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Fernando+Sabino>`__
--  **Livros:** `André Vianco <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=André+Vianco>`__
--  **Livros:** `Hackers and Painters <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Hackers+and+Painters>`__
+-  **Música:** `Hugh Laurie`_
+-  **Filmes:** `Novela`_
+-  **Filmes:** `Lisbela e o Prisioneiro`_
+-  **Filmes:** `Homem de Ferro`_
+-  **Filmes:** `Batman`_
+-  **Filmes:** `Os Vingadores`_
+-  **Livros:** `Longe é um lugar que não existe`_
+-  **Livros:** `Richard Bach`_
+-  **Livros:** `Fernão Capelo Gaivota`_
+-  **Livros:** `Para Gostar de Ler`_
+-  **Livros:** `Carlos Drummond de Andrade`_
+-  **Livros:** `Ben Alves`_
+-  **Livros:** `Fernando Sabino`_
+-  **Livros:** `André Vianco`_
+-  **Livros:** `Hackers and Painters`_
 
 Links
 -----
--  `Google <https://duckduckgo.com/?q=Google>`__
--  `Linked.in <https://duckduckgo.com/?q=Linked.in>`__
--  `Bit Twiddler <https://duckduckgo.com/?q=Bit+Twiddler>`__
--  `GMail <https://duckduckgo.com/?q=GMail>`__
--  `Ubuntu BR <https://duckduckgo.com/?q=Ubuntu+BR>`__
--  `Rodrigo Pereira <https://duckduckgo.com/?q=Rodrigo+Pereira>`__
--  `Lake Louise <https://duckduckgo.com/?q=Lake+Louise>`__
--  `Google Pounds <https://duckduckgo.com/?q=Google+Pounds>`__
--  `Mountain View <https://duckduckgo.com/?q=Mountain+View>`__
--  `Ubuntu Desktop Summit <https://duckduckgo.com/?q=Ubuntu+Desktop+Summit>`__
--  `Charles Cafe Google <https://duckduckgo.com/?q=Charles+Cafe+Google>`__
--  `XBox <https://duckduckgo.com/?q=XBox>`__
--  `StarWars <https://duckduckgo.com/?q=StarWars>`__
--  `Marvel <https://duckduckgo.com/?q=Marvel>`__
--  `Anime <https://duckduckgo.com/?q=Anime>`__
--  `Death Note <https://duckduckgo.com/?q=Death+Note>`__
--  `Gangnam Style <https://duckduckgo.com/?q=Gangnam+Style>`__
--  `Transifex <https://duckduckgo.com/?q=Transifex>`__
--  `DataCenter: Chile <http://www.google.com/about/datacenters/locations/quilicura/>`__
--  `DataCenter: North Carolina <http://www.google.com/about/datacenters/locations/lenoir/>`__
+-  `Google`_
+-  `Linked.in`_
+-  `Bit Twiddler`_
+-  `GMail`_
+-  `Ubuntu BR`_
+-  `Rodrigo Pereira`_
+-  `Lake Louise`_
+-  `Google Pounds`_
+-  `Mountain View`_
+-  `Ubuntu Desktop Summit`_
+-  `Charles Cafe Google`_
+-  `XBox`_
+-  `StarWars`_
+-  `Marvel`_
+-  `Anime`_
+-  `Death Note`_
+-  `Gangnam Style (DuckDuckGo)`_
+-  `Transifex`_
+-  `DataCenter - Chile`_
+-  `DataCenter - North Carolina`_
 
 .. class:: panel-body bg-info
 
@@ -114,3 +113,40 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _Gangnam Style: https://www.youtube.com/watch?v=9bZkp7q19f0
+.. _aqui: http://bit.ly/QTNlg0
+.. _Hugh Laurie: http://www.last.fm/search?q=Hugh+Laurie
+.. _Novela: http://www.imdb.com/find?s=all&q=Novela
+.. _Lisbela e o Prisioneiro: http://www.imdb.com/find?s=all&q=Lisbela+e+o+Prisioneiro
+.. _Homem de Ferro: http://www.imdb.com/find?s=all&q=Homem+de+Ferro
+.. _Batman: http://www.imdb.com/find?s=all&q=Batman
+.. _Os Vingadores: http://www.imdb.com/find?s=all&q=Os+Vingadores
+.. _Longe é um lugar que não existe: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Longe+é+um+lugar+que+não+existe
+.. _Richard Bach: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Richard+Bach
+.. _Fernão Capelo Gaivota: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Fernão+Capelo+Gaivota
+.. _Para Gostar de Ler: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Para+Gostar+de+Ler
+.. _Carlos Drummond de Andrade: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Carlos+Drummond+de+Andrade
+.. _Ben Alves: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Ben+Alves
+.. _Fernando Sabino: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Fernando+Sabino
+.. _André Vianco: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=André+Vianco
+.. _Hackers and Painters: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Hackers+and+Painters
+.. _Google: https://duckduckgo.com/?q=Google
+.. _Linked.in: https://duckduckgo.com/?q=Linked.in
+.. _Bit Twiddler: https://duckduckgo.com/?q=Bit+Twiddler
+.. _GMail: https://duckduckgo.com/?q=GMail
+.. _Ubuntu BR: https://duckduckgo.com/?q=Ubuntu+BR
+.. _Rodrigo Pereira: https://duckduckgo.com/?q=Rodrigo+Pereira
+.. _Lake Louise: https://duckduckgo.com/?q=Lake+Louise
+.. _Google Pounds: https://duckduckgo.com/?q=Google+Pounds
+.. _Mountain View: https://duckduckgo.com/?q=Mountain+View
+.. _Ubuntu Desktop Summit: https://duckduckgo.com/?q=Ubuntu+Desktop+Summit
+.. _Charles Cafe Google: https://duckduckgo.com/?q=Charles+Cafe+Google
+.. _XBox: https://duckduckgo.com/?q=XBox
+.. _StarWars: https://duckduckgo.com/?q=StarWars
+.. _Marvel: https://duckduckgo.com/?q=Marvel
+.. _Anime: https://duckduckgo.com/?q=Anime
+.. _Death Note: https://duckduckgo.com/?q=Death+Note
+.. _Gangnam Style (DuckDuckGo): https://duckduckgo.com/?q=Gangnam+Style
+.. _Transifex: https://duckduckgo.com/?q=Transifex
+.. _DataCenter - Chile: http://www.google.com/about/datacenters/locations/quilicura/
+.. _DataCenter - North Carolina: http://www.google.com/about/datacenters/locations/lenoir/

--- a/content/episodes/046-carlos-brando-e-rafael-rosa-fu-grokpodcast-part-1.rst
+++ b/content/episodes/046-carlos-brando-e-rafael-rosa-fu-grokpodcast-part-1.rst
@@ -12,13 +12,11 @@ Carlos Brando e Rafael Rosa Fu: GrokPodcast - Part 1
 
    Carlos Brando e Rafael Rosa Fu: GrokPodcast
 
-Olá pessoal e sejam muito bem vindos ao primeiro episódio de outubro!
-Desta vez eu tive a oportunidade de conversar pelo **Google Hangout**
-com o **Carlos Brando** e **Rafael Rosa Fu** do
-`**GrokPodcast** <http://grokpodcast.com/>`__! Foi super divertido
-conversar com eles, e o bate-papo foi tão bom que eu decidi dividir a
-entrevista em duas partes para ficar mais conveninente para vocês
-escutarem.
+Olá pessoal e sejam muito bem vindos ao primeiro episódio de outubro!  Desta
+vez eu tive a oportunidade de conversar pelo **Google Hangout** com o **Carlos
+Brando** e **Rafael Rosa Fu** do `**GrokPodcast**`_! Foi super divertido
+conversar com eles, e o bate-papo foi tão bom que eu decidi dividir
+a entrevista em duas partes para ficar mais conveninente para vocês escutarem.
 
 Nesta primeira parte conversamos sobre como que a idéia de criar o
 podcast surgiu em um barzinho em São Paulo, quando o Brando e Rafael
@@ -42,12 +40,11 @@ trabalha no **iWeb**.
 
 No próximo episódio vocês poderam também conhecer um pouco mais sobre o
 lado pessoal e background deles, inclusive como que eles são tão
-diferentes, mas se combinam tão bem! Serão eles o "`Odd
-Couple <https://en.wikipedia.org/wiki/The_Odd_Couple_(TV_series)>`__\ "?
+diferentes, mas se combinam tão bem! Serão eles o "`Odd Couple`_"?
 :)
 
 Claro que vocês podem também assistir o vídeo da entrevista no canal do
-`Youtube <http://bit.ly/QDn1p2>`__!
+`Youtube`_!
 
 Escute Agora
 ------------
@@ -75,42 +72,42 @@ Resumo
 
 Links
 -----
--  `Rails Podcast Brasil <https://duckduckgo.com/?q=Rails+Podcast+Brasil>`__
--  `Fábio Akita <https://duckduckgo.com/?q=Fábio+Akita>`__
--  `RubyConf <https://duckduckgo.com/?q=RubyConf>`__
--  `Ruby Inside <https://duckduckgo.com/?q=Ruby+Inside>`__
--  `PayPal <https://duckduckgo.com/?q=PayPal>`__
--  `Ruby on Rails <https://duckduckgo.com/?q=Ruby+on+Rails>`__
--  `Founders at Work: Stories of Startups' Early Days <https://duckduckgo.com/?q=Founders+at+Work:+Stories+of+Startups'+Early+Days>`__
--  `Jessica Livingston <https://duckduckgo.com/?q=Jessica+Livingston>`__
--  `José Valim <https://duckduckgo.com/?q=José+Valim>`__
--  `Rework <https://duckduckgo.com/?q=Rework>`__
--  `Jason Fried <https://duckduckgo.com/?q=Jason+Fried>`__
--  `Skype <https://duckduckgo.com/?q=Skype>`__
--  `Audacity <https://duckduckgo.com/?q=Audacity>`__
--  `Garage Band <https://duckduckgo.com/?q=Garage+Band>`__
--  `.NET <https://duckduckgo.com/?q=.NET>`__
--  `Python <https://duckduckgo.com/?q=Python>`__
--  `PHP <https://duckduckgo.com/?q=PHP>`__
--  `Scala <https://duckduckgo.com/?q=Scala>`__
--  `Arduino <https://duckduckgo.com/?q=Arduino>`__
--  `Wikipedia <https://duckduckgo.com/?q=Wikipedia>`__
--  `Erlang <https://duckduckgo.com/?q=Erlang>`__
--  `X4 Internet Development Solutions <https://duckduckgo.com/?q=X4+Internet+Development+Solutions>`__
--  `Webbynode <https://duckduckgo.com/?q=Webbynode>`__
--  `WordPress <https://duckduckgo.com/?q=WordPress>`__
--  `Dreamhost <https://duckduckgo.com/?q=Dreamhost>`__
--  `iWeb Hosting <https://duckduckgo.com/?q=iWeb+Hosting>`__
--  `2Pay <https://duckduckgo.com/?q=2Pay>`__
--  `Telecom Group <https://duckduckgo.com/?q=Telecom+Group>`__
--  `AT&T <https://duckduckgo.com/?q=AT&T>`__
--  `DirecTV <https://duckduckgo.com/?q=DirecTV>`__
--  `VISA <https://duckduckgo.com/?q=VISA>`__
--  `Sociably <https://duckduckgo.com/?q=Sociably>`__
--  `CarlosBrando OS <https://duckduckgo.com/?q=CarlosBrando+OS>`__
--  `Sushi <https://duckduckgo.com/?q=Sushi>`__
--  `Rdio <https://duckduckgo.com/?q=Rdio>`__
--  `DatabaseCast <https://duckduckgo.com/?q=DatabaseCast>`__
+-  `Rails Podcast Brasil`_
+-  `Fábio Akita`_
+-  `RubyConf`_
+-  `Ruby Inside`_
+-  `PayPal`_
+-  `Ruby on Rails`_
+-  `Founders at Work - Stories of Startups' Early Days`_
+-  `Jessica Livingston`_
+-  `José Valim`_
+-  `Rework`_
+-  `Jason Fried`_
+-  `Skype`_
+-  `Audacity`_
+-  `Garage Band`_
+-  `.NET`_
+-  `Python`_
+-  `PHP`_
+-  `Scala`_
+-  `Arduino`_
+-  `Wikipedia`_
+-  `Erlang`_
+-  `X4 Internet Development Solutions`_
+-  `Webbynode`_
+-  `WordPress`_
+-  `Dreamhost`_
+-  `iWeb Hosting`_
+-  `2Pay`_
+-  `Telecom Group`_
+-  `AT&T`_
+-  `DirecTV`_
+-  `VISA`_
+-  `Sociably`_
+-  `CarlosBrando OS`_
+-  `Sushi`_
+-  `Rdio`_
+-  `DatabaseCast`_
 
 .. class:: panel-body bg-info
 
@@ -119,3 +116,42 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _**GrokPodcast**: http://grokpodcast.com/
+.. _Odd Couple: https://en.wikipedia.org/wiki/The_Odd_Couple_(TV_series)
+.. _Youtube: http://bit.ly/QDn1p2
+.. _Rails Podcast Brasil: https://duckduckgo.com/?q=Rails+Podcast+Brasil
+.. _Fábio Akita: https://duckduckgo.com/?q=Fábio+Akita
+.. _RubyConf: https://duckduckgo.com/?q=RubyConf
+.. _Ruby Inside: https://duckduckgo.com/?q=Ruby+Inside
+.. _PayPal: https://duckduckgo.com/?q=PayPal
+.. _Ruby on Rails: https://duckduckgo.com/?q=Ruby+on+Rails
+.. _Founders at Work - Stories of Startups' Early Days: https://duckduckgo.com/?q=Founders+at+Work:+Stories+of+Startups'+Early+Days
+.. _Jessica Livingston: https://duckduckgo.com/?q=Jessica+Livingston
+.. _José Valim: https://duckduckgo.com/?q=José+Valim
+.. _Rework: https://duckduckgo.com/?q=Rework
+.. _Jason Fried: https://duckduckgo.com/?q=Jason+Fried
+.. _Skype: https://duckduckgo.com/?q=Skype
+.. _Audacity: https://duckduckgo.com/?q=Audacity
+.. _Garage Band: https://duckduckgo.com/?q=Garage+Band
+.. _.NET: https://duckduckgo.com/?q=.NET
+.. _Python: https://duckduckgo.com/?q=Python
+.. _PHP: https://duckduckgo.com/?q=PHP
+.. _Scala: https://duckduckgo.com/?q=Scala
+.. _Arduino: https://duckduckgo.com/?q=Arduino
+.. _Wikipedia: https://duckduckgo.com/?q=Wikipedia
+.. _Erlang: https://duckduckgo.com/?q=Erlang
+.. _X4 Internet Development Solutions: https://duckduckgo.com/?q=X4+Internet+Development+Solutions
+.. _Webbynode: https://duckduckgo.com/?q=Webbynode
+.. _WordPress: https://duckduckgo.com/?q=WordPress
+.. _Dreamhost: https://duckduckgo.com/?q=Dreamhost
+.. _iWeb Hosting: https://duckduckgo.com/?q=iWeb+Hosting
+.. _2Pay: https://duckduckgo.com/?q=2Pay
+.. _Telecom Group: https://duckduckgo.com/?q=Telecom+Group
+.. _AT&T: https://duckduckgo.com/?q=AT&T
+.. _DirecTV: https://duckduckgo.com/?q=DirecTV
+.. _VISA: https://duckduckgo.com/?q=VISA
+.. _Sociably: https://duckduckgo.com/?q=Sociably
+.. _CarlosBrando OS: https://duckduckgo.com/?q=CarlosBrando+OS
+.. _Sushi: https://duckduckgo.com/?q=Sushi
+.. _Rdio: https://duckduckgo.com/?q=Rdio
+.. _DatabaseCast: https://duckduckgo.com/?q=DatabaseCast

--- a/content/episodes/047-carlos-brando-e-rafael-rosa-fu-grokpodcast-part-2.rst
+++ b/content/episodes/047-carlos-brando-e-rafael-rosa-fu-grokpodcast-part-2.rst
@@ -13,20 +13,19 @@ Carlos Brando e Rafael Rosa Fu: GrokPodcast - Part 2
    Carlos Brando e Rafael Rosa Fu: GrokPodcast
 
 Olá pessoal e sejam muito bem vindos a mais um episódio, desta vez sendo
-publicado da cidade de Brno na República Tcheca (estou aqui à trabalho)!
-Como prometido no último episódio, esta é a segunda parte da entrevista
-que eu fiz com o **Carlos Brando** e **Rafael Rosa Fu** do
-`**GrokPodcast** <http://grokpodcast.com/>`__! Desta vez o assunto da
-vez foi sobre o background de cada um, e algumas coisas bem
-interessantes que cada um já fez em suas vidas. Quem tem 5 gatos? Quem
-já escreveu alguns livros sobre Ruby on Rails? Quem curte comédias e
-quem recentemente assistiu um filme sobre sushi? Escutem o finalzinho do
-nosso bate-papo para descrobir! :)
+publicado da cidade de Brno na República Tcheca (estou aqui à trabalho)!  Como
+prometido no último episódio, esta é a segunda parte da entrevista que eu fiz
+com o **Carlos Brando** e **Rafael Rosa Fu** do `**GrokPodcast**`_! Desta vez
+o assunto da vez foi sobre o background de cada um, e algumas coisas bem
+interessantes que cada um já fez em suas vidas. Quem tem 5 gatos? Quem já
+escreveu alguns livros sobre Ruby on Rails? Quem curte comédias e quem
+recentemente assistiu um filme sobre sushi? Escutem o finalzinho do nosso
+bate-papo para descrobir! :)
 
 .. more
 
 Claro que vocês podem também assistir o vídeo da entrevista no canal do
-`Youtube <http://bit.ly/QDn1p2>`__!
+`Youtube`_!
 
 Escute Agora
 ------------
@@ -54,42 +53,42 @@ Resumo
 
 Links
 -----
--  `Rails Podcast Brasil <https://duckduckgo.com/?q=Rails+Podcast+Brasil>`__
--  `Fábio Akita <https://duckduckgo.com/?q=Fábio+Akita>`__
--  `RubyConf <https://duckduckgo.com/?q=RubyConf>`__
--  `Ruby Inside <https://duckduckgo.com/?q=Ruby+Inside>`__
--  `PayPal <https://duckduckgo.com/?q=PayPal>`__
--  `Ruby on Rails <https://duckduckgo.com/?q=Ruby+on+Rails>`__
--  `Founders at Work: Stories of Startups' Early Days <https://duckduckgo.com/?q=Founders+at+Work:+Stories+of+Startups'+Early+Days>`__
--  `Jessica Livingston <https://duckduckgo.com/?q=Jessica+Livingston>`__
--  `José Valim <https://duckduckgo.com/?q=José+Valim>`__
--  `Rework <https://duckduckgo.com/?q=Rework>`__
--  `Jason Fried <https://duckduckgo.com/?q=Jason+Fried>`__
--  `Skype <https://duckduckgo.com/?q=Skype>`__
--  `Audacity <https://duckduckgo.com/?q=Audacity>`__
--  `Garage Band <https://duckduckgo.com/?q=Garage+Band>`__
--  `.NET <https://duckduckgo.com/?q=.NET>`__
--  `Python <https://duckduckgo.com/?q=Python>`__
--  `PHP <https://duckduckgo.com/?q=PHP>`__
--  `Scala <https://duckduckgo.com/?q=Scala>`__
--  `Arduino <https://duckduckgo.com/?q=Arduino>`__
--  `Wikipedia <https://duckduckgo.com/?q=Wikipedia>`__
--  `Erlang <https://duckduckgo.com/?q=Erlang>`__
--  `X4 Internet Development Solutions <https://duckduckgo.com/?q=X4+Internet+Development+Solutions>`__
--  `Webbynode <https://duckduckgo.com/?q=Webbynode>`__
--  `WordPress <https://duckduckgo.com/?q=WordPress>`__
--  `Dreamhost <https://duckduckgo.com/?q=Dreamhost>`__
--  `iWeb Hosting <https://duckduckgo.com/?q=iWeb+Hosting>`__
--  `2Pay <https://duckduckgo.com/?q=2Pay>`__
--  `Telecom Group <https://duckduckgo.com/?q=Telecom+Group>`__
--  `AT&T <https://duckduckgo.com/?q=AT&T>`__
--  `DirecTV <https://duckduckgo.com/?q=DirecTV>`__
--  `VISA <https://duckduckgo.com/?q=VISA>`__
--  `Sociably <https://duckduckgo.com/?q=Sociably>`__
--  `CarlosBrando OS <https://duckduckgo.com/?q=CarlosBrando+OS>`__
--  `Sushi <https://duckduckgo.com/?q=Sushi>`__
--  `Rdio <https://duckduckgo.com/?q=Rdio>`__
--  `DatabaseCast <https://duckduckgo.com/?q=DatabaseCast>`__
+-  `Rails Podcast Brasil`_
+-  `Fábio Akita`_
+-  `RubyConf`_
+-  `Ruby Inside`_
+-  `PayPal`_
+-  `Ruby on Rails`_
+-  `Founders at Work - Stories of Startups' Early Days`_
+-  `Jessica Livingston`_
+-  `José Valim`_
+-  `Rework`_
+-  `Jason Fried`_
+-  `Skype`_
+-  `Audacity`_
+-  `Garage Band`_
+-  `.NET`_
+-  `Python`_
+-  `PHP`_
+-  `Scala`_
+-  `Arduino`_
+-  `Wikipedia`_
+-  `Erlang`_
+-  `X4 Internet Development Solutions`_
+-  `Webbynode`_
+-  `WordPress`_
+-  `Dreamhost`_
+-  `iWeb Hosting`_
+-  `2Pay`_
+-  `Telecom Group`_
+-  `AT&T`_
+-  `DirecTV`_
+-  `VISA`_
+-  `Sociably`_
+-  `CarlosBrando OS`_
+-  `Sushi`_
+-  `Rdio`_
+-  `DatabaseCast`_
 
 .. class:: panel-body bg-info
 
@@ -98,3 +97,41 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _**GrokPodcast**: http://grokpodcast.com/
+.. _Youtube: http://bit.ly/QDn1p2
+.. _Rails Podcast Brasil: https://duckduckgo.com/?q=Rails+Podcast+Brasil
+.. _Fábio Akita: https://duckduckgo.com/?q=Fábio+Akita
+.. _RubyConf: https://duckduckgo.com/?q=RubyConf
+.. _Ruby Inside: https://duckduckgo.com/?q=Ruby+Inside
+.. _PayPal: https://duckduckgo.com/?q=PayPal
+.. _Ruby on Rails: https://duckduckgo.com/?q=Ruby+on+Rails
+.. _Founders at Work - Stories of Startups' Early Days: https://duckduckgo.com/?q=Founders+at+Work:+Stories+of+Startups'+Early+Days
+.. _Jessica Livingston: https://duckduckgo.com/?q=Jessica+Livingston
+.. _José Valim: https://duckduckgo.com/?q=José+Valim
+.. _Rework: https://duckduckgo.com/?q=Rework
+.. _Jason Fried: https://duckduckgo.com/?q=Jason+Fried
+.. _Skype: https://duckduckgo.com/?q=Skype
+.. _Audacity: https://duckduckgo.com/?q=Audacity
+.. _Garage Band: https://duckduckgo.com/?q=Garage+Band
+.. _.NET: https://duckduckgo.com/?q=.NET
+.. _Python: https://duckduckgo.com/?q=Python
+.. _PHP: https://duckduckgo.com/?q=PHP
+.. _Scala: https://duckduckgo.com/?q=Scala
+.. _Arduino: https://duckduckgo.com/?q=Arduino
+.. _Wikipedia: https://duckduckgo.com/?q=Wikipedia
+.. _Erlang: https://duckduckgo.com/?q=Erlang
+.. _X4 Internet Development Solutions: https://duckduckgo.com/?q=X4+Internet+Development+Solutions
+.. _Webbynode: https://duckduckgo.com/?q=Webbynode
+.. _WordPress: https://duckduckgo.com/?q=WordPress
+.. _Dreamhost: https://duckduckgo.com/?q=Dreamhost
+.. _iWeb Hosting: https://duckduckgo.com/?q=iWeb+Hosting
+.. _2Pay: https://duckduckgo.com/?q=2Pay
+.. _Telecom Group: https://duckduckgo.com/?q=Telecom+Group
+.. _AT&T: https://duckduckgo.com/?q=AT&T
+.. _DirecTV: https://duckduckgo.com/?q=DirecTV
+.. _VISA: https://duckduckgo.com/?q=VISA
+.. _Sociably: https://duckduckgo.com/?q=Sociably
+.. _CarlosBrando OS: https://duckduckgo.com/?q=CarlosBrando+OS
+.. _Sushi: https://duckduckgo.com/?q=Sushi
+.. _Rdio: https://duckduckgo.com/?q=Rdio
+.. _DatabaseCast: https://duckduckgo.com/?q=DatabaseCast

--- a/content/episodes/048-julian-fernandes-ubuntu-br-sc.rst
+++ b/content/episodes/048-julian-fernandes-ubuntu-br-sc.rst
@@ -12,48 +12,39 @@ Julian Fernandes: Ubuntu BR SC
 
    Julian Fernandes: Ubuntu BR SC
 
-Demorou mais chegou!!! Devido a `problemas
-pessoais <http://www.castalio.info/aviso-aos-navegantes/>`__ eu
-infelizmente fiquei um pouco sem tempo para agendar as minhas
-entrevistas, mas te garanto que foi super difícil para mim deixar de
-publicar a cada 2 semanas. Mas nada como um pouco de tempo para colocar
-a vida de novo nos trilhos, e eu quero agradecer a todos que me enviaram
-mensagems de apoio aqui, por e-mail e pelas várias redes sociais que
-uso!
+Demorou mais chegou!!! Devido a `problemas pessoais`_ eu infelizmente fiquei
+um pouco sem tempo para agendar as minhas entrevistas, mas te garanto que foi
+super difícil para mim deixar de publicar a cada 2 semanas. Mas nada como um
+pouco de tempo para colocar a vida de novo nos trilhos, e eu quero agradecer
+a todos que me enviaram mensagems de apoio aqui, por e-mail e pelas várias
+redes sociais que uso!
 
-Então, para celebrar a nossa volta, quero dedicar este episódio ao
-`André Gondim <http://bit.ly/VfgrTE>`__, que há um ano atrás nos deixou
-de uma forma tão súbita! O André foi parte da vida de muitas pessoas, e
-na minha opinião, a "cara" do Ubuntu no Brasil!
+Então, para celebrar a nossa volta, quero dedicar este episódio ao `André
+Gondim`_, que há um ano atrás nos deixou de uma forma tão súbita! O André foi
+parte da vida de muitas pessoas, e na minha opinião, a "cara" do Ubuntu no
+Brasil!
 
-O convidado deste episódio é o `Julian
-Fernandes <http://www.julianfernandes.com/>`__, um dos criadores e
-mantenedores do `Ubuntu BR SC <http://www.ubuntubrsc.com/>`__, um dos
-sites mais visitados pelos usuários de Linux (e não só usuários do
-Ubuntu Linux, diz o Julian) brasileiros buscando notícias ou tutoriais
-para dar uma "perfumada" em seus sistemas ou configurar algum
-dispositivo ou serviço! Com uma média de 8 a 10 mil visitantes por dia,
-o Ubuntu BR SC conta com uma equipe super dinâmica que está sempre
-adicionando conteúdo ou respondendo os comentários e perguntas de seus
-visitantes.
+O convidado deste episódio é o `Julian Fernandes`_, um dos criadores
+e mantenedores do `Ubuntu BR SC`_, um dos sites mais visitados pelos usuários
+de Linux (e não só usuários do Ubuntu Linux, diz o Julian) brasileiros buscando
+notícias ou tutoriais para dar uma "perfumada" em seus sistemas ou configurar
+algum dispositivo ou serviço! Com uma média de 8 a 10 mil visitantes por dia,
+o Ubuntu BR SC conta com uma equipe super dinâmica que está sempre adicionando
+conteúdo ou respondendo os comentários e perguntas de seus visitantes.
 
 .. more
 
-Durante nosso bate-papo conversamos sobre como que o site **Ubuntu BR
-SC** nasceu, quais as ferramentas e tecnologias que são usadas, quem são
-os integrantes da equipe responsável pela geração e seleção de artigos,
-e quais os planos para 2013 (dica: grandes surpresas por vir em
-janeiro!!!). Também falamos sobre seu gosto por música (depois cheque o
-`canal <http://www.youtube.com/user/JuHitoriX>`__ que ele tem no
-**Youtube** com algumas de suas apresentações, incluindo ele tocando
-`Knocking on Heavens
-Door <http://www.youtube.com/watch?v=-wv0K9S7xbA&list=UUVwPM6qoLRlRJJbucSOXzug&index=4&feature=plcp>`__),
-o fato dele ter parado a universidade para trabalhar no site, seu Top 5,
-e como que vocês podem ajudar a manter o site no ar!
+Durante nosso bate-papo conversamos sobre como que o site **Ubuntu BR SC**
+nasceu, quais as ferramentas e tecnologias que são usadas, quem são os
+integrantes da equipe responsável pela geração e seleção de artigos, e quais os
+planos para 2013 (dica: grandes surpresas por vir em janeiro!!!). Também
+falamos sobre seu gosto por música (depois cheque o `canal`_ que ele tem no
+**Youtube** com algumas de suas apresentações, incluindo ele tocando `Knocking
+on Heavens Door`_), o fato dele ter parado a universidade para trabalhar no
+site, seu Top 5, e como que vocês podem ajudar a manter o site no ar!
 
-Tem também o `vídeo <http://bit.ly/XgekVI>`__ da entrevista, mas como o
-Julian teve problemas com a web cam, vocês só vão me ver (e minha barba
-de 1 mês) :)
+Tem também o `vídeo`_ da entrevista, mas como o Julian teve problemas com
+a web cam, vocês só vão me ver (e minha barba de 1 mês) :)
 
 Escute Agora
 ------------
@@ -75,3 +66,10 @@ Contato
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _problemas pessoais: http://www.castalio.info/aviso-aos-navegantes/
+.. _André Gondim: http://bit.ly/VfgrTE
+.. _Julian Fernandes: http://www.julianfernandes.com/
+.. _Ubuntu BR SC: http://www.ubuntubrsc.com/
+.. _canal: http://www.youtube.com/user/JuHitoriX
+.. _Knocking on Heavens Door: http://www.youtube.com/watch?v=-wv0K9S7xbA&list=UUVwPM6qoLRlRJJbucSOXzug&index=4&feature=plcp
+.. _vídeo: http://bit.ly/XgekVI

--- a/content/episodes/049-fabiano-fidencio-red-hat.rst
+++ b/content/episodes/049-fabiano-fidencio-red-hat.rst
@@ -12,28 +12,25 @@ Fabiano Fidêncio: Red Hat
 
    Fabiano Fidêncio: Red Hat
 
-Para o primeiro episódio de 2013 eu tive o prazer de entrevistar o
-**Fabiano Fidêncio**, recém contratado pela **Red Hat**! Durante nosso
-bate-papo o Fabiano conta como que ele aprendeu a programar "de verdade"
-na `ProFUSION <http://www.profusion.mobi/>`__ e como que de usuário
-**GNOME**, ele se transformou em desenvolvedor quando começou a
-trabalhar no `GNOME Boxes <https://live.gnome.org/Boxes>`__ e
-`libosinfo <https://www.redhat.com/mailman/listinfo/libosinfo>`__ pelo
-**Google Summer of Code**. Sua participação neste projeto foi muito
-interessante, já que ele teve de aproveitar um código base escrito por
-uma pessoa da Red Hat e refatorar para que ficasse mais limpo e
-genérico, algo que não é super fácil de fazer. O projeto acabou virando
-mais que um hobby, e devido ao seu trabalho o Fabiano acabou sendo
-contratado para trabalhar na Red Hat a partir de março! Não vou revelar
-qual o projeto que ele vai trabalhar (você vai ter de escutar o
-episódio), mas além de trabalho novo, ele também vai se mudar do Brasil
-para uma cidade européia, onde cerveja é mais barato que água!
+Para o primeiro episódio de 2013 eu tive o prazer de entrevistar o **Fabiano
+Fidêncio**, recém contratado pela **Red Hat**! Durante nosso bate-papo
+o Fabiano conta como que ele aprendeu a programar "de verdade" na `ProFUSION`_
+e como que de usuário **GNOME**, ele se transformou em desenvolvedor quando
+começou a trabalhar no `GNOME Boxes`_ e `libosinfo`_ pelo **Google Summer of
+Code**. Sua participação neste projeto foi muito interessante, já que ele teve
+de aproveitar um código base escrito por uma pessoa da Red Hat e refatorar para
+que ficasse mais limpo e genérico, algo que não é super fácil de fazer.
+O projeto acabou virando mais que um hobby, e devido ao seu trabalho o Fabiano
+acabou sendo contratado para trabalhar na Red Hat a partir de março! Não vou
+revelar qual o projeto que ele vai trabalhar (você vai ter de escutar
+o episódio), mas além de trabalho novo, ele também vai se mudar do Brasil para
+uma cidade européia, onde cerveja é mais barato que água!
 
 .. more
 
-Como sempre, a entrevista foi gravada por vídeo e você pode assistir
-nosso bate-papo na íntegra e sem edição `aqui <http://bit.ly/Vfblgu>`__,
-incluindo como que ele está se preparando para se mudar para a europa!
+Como sempre, a entrevista foi gravada por vídeo e você pode assistir nosso
+bate-papo na íntegra e sem edição `aqui`_, incluindo como que ele está se
+preparando para se mudar para a europa!
 
 Escute Agora
 ------------
@@ -42,58 +39,58 @@ Escute Agora
 
 Contato
 -------
--  `Blog <http://blog.fidencio.org/>`__
--  `Google+ <https://plus.google.com/116512253405346448508>`__
--  `Facebook <https://www.facebook.com/fabianofidencio>`__
--  `Twitter <https://twitter.com/ffidencio>`__
+-  `Blog`_
+-  `Google+`_
+-  `Facebook`_
+-  `Twitter`_
 
 Top 5
 -----
 -  **Música**
 
-   -  `Tim Maia <http://www.last.fm/music/Tim+Maia?ac=tim%20maia>`__
-   -  `Criolo <http://www.criolo.net/music.html>`__
-   -  `Arnaldo Baptista <http://www.arnaldobaptista.com.br/>`__
-   -  `Os Mutantes <http://www.last.fm/music/Os+Mutantes?ac=os%20muta>`__
-   -  `Taquinho Noronha <http://www.myspace.com/taquinhonoronha>`__
-   -  `The Name <http://www.myspace.com/thenamemusik>`__
-   -  `Club America <https://www.facebook.com/clubclubamerica>`__
-   -  `Schoolbell <https://soundcloud.com/rwbclub/schoobell-spin-me>`__
-   -  `Bonde do Rolê <https://soundcloud.com/bondedorole>`__
-   -  `Pink Floyd <http://www.last.fm/music/Pink+Floyd?ac=pink>`__
-   -  `Led Zeppelin <http://www.last.fm/music/Led+Zeppelin?ac=led%20zep>`__
-   -  `Panthera <http://www.last.fm/music/Pantera?ac=pantera>`__
-   -  `Miles Davis <http://www.last.fm/music/Miles+Davis?ac=miles>`__
+   -  `Tim Maia`_
+   -  `Criolo`_
+   -  `Arnaldo Baptista`_
+   -  `Os Mutantes`_
+   -  `Taquinho Noronha`_
+   -  `The Name`_
+   -  `Club America`_
+   -  `Schoolbell`_
+   -  `Bonde do Rolê`_
+   -  `Pink Floyd`_
+   -  `Led Zeppelin`_
+   -  `Panthera`_
+   -  `Miles Davis`_
 
 -  **Filmes/Televisão:**
 
-   -  `House M.D. <http://www.imdb.com/title/tt0412142/>`__
-   -  `Dexter <http://www.imdb.com/title/tt0773262/>`__
-   -  `El Chavo <http://www.imdb.com/title/tt0229889/>`__
-   -  `Quentin Tarantino <http://www.imdb.com/name/nm0000233/>`__
+   -  `House M.D.`_
+   -  `Dexter`_
+   -  `El Chavo`_
+   -  `Quentin Tarantino`_
 
 Links
 -----
--  `Planet GNOME <https://duckduckgo.com/?q=Planet+GNOME>`__
--  `Google Summer of Code <https://duckduckgo.com/?q=Google+Summer+of+Code>`__
--  `GOME Boxes <https://duckduckgo.com/?q=GOME+Boxes>`__
--  `libosinfo <https://duckduckgo.com/?q=libosinfo>`__
--  `VMWare Player <https://duckduckgo.com/?q=VMWare+Player>`__
--  `kickstart <https://duckduckgo.com/?q=kickstart>`__
--  `Red Hat <https://duckduckgo.com/?q=Red+Hat>`__
--  `Fedora Linux <https://duckduckgo.com/?q=Fedora+Linux>`__
--  `EFL <https://duckduckgo.com/?q=EFL>`__
--  `Zeeshan Ali <https://duckduckgo.com/?q=Zeeshan+Ali>`__
--  `Daniel Berrange <https://duckduckgo.com/?q=Daniel+Berrange>`__
--  `Virtual Box <https://duckduckgo.com/?q=Virtual+Box>`__
--  `ESX <https://duckduckgo.com/?q=ESX>`__
--  `Samba <https://duckduckgo.com/?q=Samba>`__
--  `NFS <https://duckduckgo.com/?q=NFS>`__
--  `Evolution <https://duckduckgo.com/?q=Evolution>`__
--  `GDM <https://duckduckgo.com/?q=GDM>`__
--  `GTK <https://duckduckgo.com/?q=GTK>`__
--  `Brno <https://duckduckgo.com/?q=Brno>`__
--  `South by SouthWest <https://duckduckgo.com/?q=South+by+SouthWest>`__
+-  `Planet GNOME`_
+-  `Google Summer of Code`_
+-  `GOME Boxes`_
+-  `libosinfo (DuckDuckGo)`_
+-  `VMWare Player`_
+-  `kickstart`_
+-  `Red Hat`_
+-  `Fedora Linux`_
+-  `EFL`_
+-  `Zeeshan Ali`_
+-  `Daniel Berrange`_
+-  `Virtual Box`_
+-  `ESX`_
+-  `Samba`_
+-  `NFS`_
+-  `Evolution`_
+-  `GDM`_
+-  `GTK`_
+-  `Brno`_
+-  `South by SouthWest`_
 
 .. class:: panel-body bg-info
 
@@ -102,3 +99,48 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _ProFUSION: http://www.profusion.mobi/
+.. _GNOME Boxes: https://live.gnome.org/Boxes
+.. _libosinfo: https://www.redhat.com/mailman/listinfo/libosinfo
+.. _aqui: http://bit.ly/Vfblgu
+.. _Blog: http://blog.fidencio.org/
+.. _Google+: https://plus.google.com/116512253405346448508
+.. _Facebook: https://www.facebook.com/fabianofidencio
+.. _Twitter: https://twitter.com/ffidencio
+.. _Tim Maia: http://www.last.fm/music/Tim+Maia?ac=tim%20maia
+.. _Criolo: http://www.criolo.net/music.html
+.. _Arnaldo Baptista: http://www.arnaldobaptista.com.br/
+.. _Os Mutantes: http://www.last.fm/music/Os+Mutantes?ac=os%20muta
+.. _Taquinho Noronha: http://www.myspace.com/taquinhonoronha
+.. _The Name: http://www.myspace.com/thenamemusik
+.. _Club America: https://www.facebook.com/clubclubamerica
+.. _Schoolbell: https://soundcloud.com/rwbclub/schoobell-spin-me
+.. _Bonde do Rolê: https://soundcloud.com/bondedorole
+.. _Pink Floyd: http://www.last.fm/music/Pink+Floyd?ac=pink
+.. _Led Zeppelin: http://www.last.fm/music/Led+Zeppelin?ac=led%20zep
+.. _Panthera: http://www.last.fm/music/Pantera?ac=pantera
+.. _Miles Davis: http://www.last.fm/music/Miles+Davis?ac=miles
+.. _House M.D.: http://www.imdb.com/title/tt0412142/
+.. _Dexter: http://www.imdb.com/title/tt0773262/
+.. _El Chavo: http://www.imdb.com/title/tt0229889/
+.. _Quentin Tarantino: http://www.imdb.com/name/nm0000233/
+.. _Planet GNOME: https://duckduckgo.com/?q=Planet+GNOME
+.. _Google Summer of Code: https://duckduckgo.com/?q=Google+Summer+of+Code
+.. _GOME Boxes: https://duckduckgo.com/?q=GOME+Boxes
+.. _libosinfo (DuckDuckGo): https://duckduckgo.com/?q=libosinfo
+.. _VMWare Player: https://duckduckgo.com/?q=VMWare+Player
+.. _kickstart: https://duckduckgo.com/?q=kickstart
+.. _Red Hat: https://duckduckgo.com/?q=Red+Hat
+.. _Fedora Linux: https://duckduckgo.com/?q=Fedora+Linux
+.. _EFL: https://duckduckgo.com/?q=EFL
+.. _Zeeshan Ali: https://duckduckgo.com/?q=Zeeshan+Ali
+.. _Daniel Berrange: https://duckduckgo.com/?q=Daniel+Berrange
+.. _Virtual Box: https://duckduckgo.com/?q=Virtual+Box
+.. _ESX: https://duckduckgo.com/?q=ESX
+.. _Samba: https://duckduckgo.com/?q=Samba
+.. _NFS: https://duckduckgo.com/?q=NFS
+.. _Evolution: https://duckduckgo.com/?q=Evolution
+.. _GDM: https://duckduckgo.com/?q=GDM
+.. _GTK: https://duckduckgo.com/?q=GTK
+.. _Brno: https://duckduckgo.com/?q=Brno
+.. _South by SouthWest: https://duckduckgo.com/?q=South+by+SouthWest

--- a/content/episodes/050-luciano-ramalho-oficinas-turing.rst
+++ b/content/episodes/050-luciano-ramalho-oficinas-turing.rst
@@ -22,39 +22,35 @@ trabalha com python, o nome do Luciano não lhe deve ser estranho. Mas
 para mim, que moro há 21 anos no exterior, foi uma descoberta super
 maneira!
 
-Quanto mais eu pesquisei sobre ele, mais animado eu ficava em conhecer
-"a pessoa por trás dos slides" das apresentações `Python: Encapsulation with Descriptors`_
-e `Iterators & generators: the Python Way`_.
-Mais gostoso ainda foi descobrir que estas **apresentações são
-inéditas** no público brasileiro e serão apresentadas na
-`PyCon`_ americana este ano! Durante nosso
-bate-papo, o Luciano me contou como que foi a criação da `Associação Python Brasil`_, quais foram seus
-primeiros objetivos e como foi o seu primeiro mandato como presidente da
-mesma. Também discutimos sobre os vários frameworks que existem para
-quem quer ser programador web com python, alguns fatos interessantes
-sobre o **Zope**, **Plone**, **Flask**, e **Web2Py**, e quais delas ele
-recomenda para quem está iniciando no mundo de programação.
+Quanto mais eu pesquisei sobre ele, mais animado eu ficava em conhecer "a
+pessoa por trás dos slides" das apresentações `Python - Encapsulation with
+Descriptors`_ e `Iterators & generators: the Python Way`_.  Mais gostoso ainda
+foi descobrir que estas **apresentações são inéditas** no público brasileiro
+e serão apresentadas na `PyCon`_ americana este ano! Durante nosso bate-papo,
+o Luciano me contou como que foi a criação da `Associação Python Brasil`_,
+quais foram seus primeiros objetivos e como foi o seu primeiro mandato como
+presidente da mesma. Também discutimos sobre os vários frameworks que existem
+para quem quer ser programador web com python, alguns fatos interessantes sobre
+o **Zope**, **Plone**, **Flask**, e **Web2Py**, e quais delas ele recomenda
+para quem está iniciando no mundo de programação.
 
 .. more
 
-Para quem estiver interessado a aprender a programar, o Luciano também
-oferece cursos online na `Oficinas Turing`_
-para iniciantes e programadores com mais experiência, como `Objetos Pythonicos`_
-e `Python para quem sabe Python`_.
+Para quem estiver interessado a aprender a programar, o Luciano também oferece
+cursos online na `Oficinas Turing`_ para iniciantes e programadores com mais
+experiência, como `Objetos Pythonicos`_ e `Python para quem sabe Python`_.
 
-Por último falamos sobre o `Garoa Hacker
-Clube <http://hackerspaces.org/wiki/Garoa_Hacker_Clube>`__ (`fotos <https://www.facebook.com/GaroaHC/photos_stream>`__),
-um **HackerSpace** que ele criou em São Paulo com uma proposta bem
-interessante: um espaço onde você pode ir para conhecer gente
-interessante e aprender a programar, usar tecnologias recentes como
-**Arduino** e **Rasberry Pi** usando a metodologia "mão na massa", e
-para quem virar sócio, sua própria chave para usar o espaço/laboratório
-qualquer hora do dia!
+Por último falamos sobre o `Garoa Hacker Clube`_ (`fotos`_), um
+**HackerSpace** que ele criou em São Paulo com uma proposta bem interessante:
+um espaço onde você pode ir para conhecer gente interessante e aprender
+a programar, usar tecnologias recentes como **Arduino** e **Rasberry Pi**
+usando a metodologia "mão na massa", e para quem virar sócio, sua própria chave
+para usar o espaço/laboratório qualquer hora do dia!
 
-O bate-papo rolou por um bom tempo, e eu tive de editar muita coisa
-bacana, mas você pode assistir o `vídeo <http://bit.ly/YPOZTO>`__ da
-entrevista e saber um pouco mais sobre os bastidores da criação da
-Associação Python Brasil e sobre os frameworks discutidos.
+O bate-papo rolou por um bom tempo, e eu tive de editar muita coisa bacana, mas
+você pode assistir o `vídeo`_ da entrevista e saber um pouco mais sobre os
+bastidores da criação da Associação Python Brasil e sobre os frameworks
+discutidos.
 
 Escute Agora
 ------------
@@ -71,58 +67,58 @@ Contato
 
 Top 5
 -----
--  **Música:** `Deep Purple <http://www.last.fm/search?q=Deep+Purple>`__
--  **Música:** `Frank Zappa <http://www.last.fm/search?q=Frank+Zappa>`__
--  **Música:** `Mozart <http://www.last.fm/search?q=Mozart>`__
--  **Música:** `Pink Floyd <http://www.last.fm/search?q=Pink+Floyd>`__
--  **Música:** `Led Zeppelin <http://www.last.fm/search?q=Led+Zeppelin>`__
--  **Música:** `Björk <http://www.last.fm/search?q=Björk>`__
--  **Música:** `Philip Glass <http://www.last.fm/search?q=Philip+Glass>`__
--  **Filmes:** `Apocalipse Now <http://www.imdb.com/find?s=all&q=Apocalipse+Now>`__
--  **Filmes:** `Brazil <http://www.imdb.com/find?s=all&q=Brazil>`__
--  **Filmes:** `Senhor dos Aneis <http://www.imdb.com/find?s=all&q=Senhor+dos+Aneis>`__
--  **Filmes:** `O Hobbit <http://www.imdb.com/find?s=all&q=O+Hobbit>`__
--  **Filmes:** `O Poderoso Chefão <http://www.imdb.com/find?s=all&q=O+Poderoso+Chefão>`__
--  **Livros:** `Império a Deriva <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Império+a+Deriva>`__
--  **Livros:** `O Hobbit <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=O+Hobbit>`__
--  **Livros:** `Estação Carandiru <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Estação+Carandiru>`__
+-  **Música:** `Deep Purple`_
+-  **Música:** `Frank Zappa`_
+-  **Música:** `Mozart`_
+-  **Música:** `Pink Floyd`_
+-  **Música:** `Led Zeppelin`_
+-  **Música:** `Björk`_
+-  **Música:** `Philip Glass`_
+-  **Filmes:** `Apocalipse Now`_
+-  **Filmes:** `Brazil`_
+-  **Filmes:** `Senhor dos Aneis`_
+-  **Filmes:** `O Hobbit`_
+-  **Filmes:** `O Poderoso Chefão`_
+-  **Livros:** `Império a Deriva`_
+-  **Livros:** `O Hobbit (Amazon)`_
+-  **Livros:** `Estação Carandiru`_
 
 Links
 -----
--  `SpeakerDeck <https://duckduckgo.com/?q=SpeakerDeck>`__
--  `Python <https://duckduckgo.com/?q=Python>`__
--  `Zope <https://duckduckgo.com/?q=Zope>`__
--  `Plone <https://duckduckgo.com/?q=Plone>`__
--  `CMS <https://duckduckgo.com/?q=CMS>`__
--  `Zope Brasil <https://duckduckgo.com/?q=Zope+Brasil>`__
--  `C++ <https://duckduckgo.com/?q=C++>`__
--  `Fortran <https://duckduckgo.com/?q=Fortran>`__
--  `Global Arrays <https://duckduckgo.com/?q=Global+Arrays>`__
--  `Petrobras <https://duckduckgo.com/?q=Petrobras>`__
--  `Django <https://duckduckgo.com/?q=Django>`__
--  `Pyramid <https://duckduckgo.com/?q=Pyramid>`__
--  `Pylons <https://duckduckgo.com/?q=Pylons>`__
--  `ZODB <https://duckduckgo.com/?q=ZODB>`__
--  `Flask <https://duckduckgo.com/?q=Flask>`__
--  `Web2Py <https://duckduckgo.com/?q=Web2Py>`__
--  `Plone Foundation <https://duckduckgo.com/?q=Plone+Foundation>`__
--  `Hora Extra <https://duckduckgo.com/?q=Hora+Extra>`__
--  `Henrique Bastos <https://duckduckgo.com/?q=Henrique+Bastos>`__
--  `Github <https://duckduckgo.com/?q=Github>`__
--  `SlideShare <https://duckduckgo.com/?q=SlideShare>`__
--  `PyCon <https://duckduckgo.com/?q=PyCon>`__
--  `iPython <https://duckduckgo.com/?q=iPython>`__
--  `Kivy Toolkit <https://duckduckgo.com/?q=Kivy+Toolkit>`__
--  `TurboGears <https://duckduckgo.com/?q=TurboGears>`__
--  `Garoa Hacker Clube <https://duckduckgo.com/?q=Garoa+Hacker+Clube>`__
--  `Coding Dojo <https://duckduckgo.com/?q=Coding+Dojo>`__
+-  `SpeakerDeck`_
+-  `Python`_
+-  `Zope`_
+-  `Plone`_
+-  `CMS`_
+-  `Zope Brasil`_
+-  `C++`_
+-  `Fortran`_
+-  `Global Arrays`_
+-  `Petrobras`_
+-  `Django`_
+-  `Pyramid`_
+-  `Pylons`_
+-  `ZODB`_
+-  `Flask`_
+-  `Web2Py`_
+-  `Plone Foundation`_
+-  `Hora Extra`_
+-  `Henrique Bastos`_
+-  `Github`_
+-  `SlideShare`_
+-  `PyCon (DuckDuckGo)`_
+-  `iPython`_
+-  `Kivy Toolkit`_
+-  `TurboGears`_
+-  `Garoa Hacker Clube (DuckDuckGo)`_
+-  `Coding Dojo`_
 
 .. class:: panel-body bg-info
 
         **Música**: `Ain't Gonna Give Jelly Roll`_ by `Red Hook Ramblers`_ is licensed under a Creative Commons Attribution-NonCommercial-NoDerivatives (aka Music Sharing) License.
 
 .. Links
-.. _`Python: Encapsulation with Descriptors`: https://speakerdeck.com/ramalho/python-encapsulation-with-descriptors
+.. _`Python - Encapsulation with Descriptors`: https://speakerdeck.com/ramalho/python-encapsulation-with-descriptors
 .. _`Iterators & generators: the Python Way`: https://speakerdeck.com/ramalho/iterators-and-generators-the-python-way
 .. _PyCon: https://us.pycon.org/2013/
 .. _Associação Python Brasil: http://associacao.python.org.br
@@ -133,3 +129,48 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _Garoa Hacker Clube: http://hackerspaces.org/wiki/Garoa_Hacker_Clube
+.. _vídeo: http://bit.ly/YPOZTO
+.. _Deep Purple: http://www.last.fm/search?q=Deep+Purple
+.. _Frank Zappa: http://www.last.fm/search?q=Frank+Zappa
+.. _Mozart: http://www.last.fm/search?q=Mozart
+.. _Pink Floyd: http://www.last.fm/search?q=Pink+Floyd
+.. _Led Zeppelin: http://www.last.fm/search?q=Led+Zeppelin
+.. _Björk: http://www.last.fm/search?q=Björk
+.. _Philip Glass: http://www.last.fm/search?q=Philip+Glass
+.. _Apocalipse Now: http://www.imdb.com/find?s=all&q=Apocalipse+Now
+.. _Brazil: http://www.imdb.com/find?s=all&q=Brazil
+.. _Senhor dos Aneis: http://www.imdb.com/find?s=all&q=Senhor+dos+Aneis
+.. _O Hobbit: http://www.imdb.com/find?s=all&q=O+Hobbit
+.. _O Poderoso Chefão: http://www.imdb.com/find?s=all&q=O+Poderoso+Chefão
+.. _Império a Deriva: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Império+a+Deriva
+.. _O Hobbit (Amazon): http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=O+Hobbit
+.. _Estação Carandiru: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Estação+Carandiru
+.. _SpeakerDeck: https://duckduckgo.com/?q=SpeakerDeck
+.. _Python: https://duckduckgo.com/?q=Python
+.. _Zope: https://duckduckgo.com/?q=Zope
+.. _Plone: https://duckduckgo.com/?q=Plone
+.. _CMS: https://duckduckgo.com/?q=CMS
+.. _Zope Brasil: https://duckduckgo.com/?q=Zope+Brasil
+.. _C++: https://duckduckgo.com/?q=C++
+.. _Fortran: https://duckduckgo.com/?q=Fortran
+.. _Global Arrays: https://duckduckgo.com/?q=Global+Arrays
+.. _Petrobras: https://duckduckgo.com/?q=Petrobras
+.. _Django: https://duckduckgo.com/?q=Django
+.. _Pyramid: https://duckduckgo.com/?q=Pyramid
+.. _Pylons: https://duckduckgo.com/?q=Pylons
+.. _ZODB: https://duckduckgo.com/?q=ZODB
+.. _Flask: https://duckduckgo.com/?q=Flask
+.. _Web2Py: https://duckduckgo.com/?q=Web2Py
+.. _Plone Foundation: https://duckduckgo.com/?q=Plone+Foundation
+.. _Hora Extra: https://duckduckgo.com/?q=Hora+Extra
+.. _Henrique Bastos: https://duckduckgo.com/?q=Henrique+Bastos
+.. _Github: https://duckduckgo.com/?q=Github
+.. _SlideShare: https://duckduckgo.com/?q=SlideShare
+.. _PyCon (DuckDuckGo): https://duckduckgo.com/?q=PyCon
+.. _iPython: https://duckduckgo.com/?q=iPython
+.. _Kivy Toolkit: https://duckduckgo.com/?q=Kivy+Toolkit
+.. _TurboGears: https://duckduckgo.com/?q=TurboGears
+.. _Garoa Hacker Clube (DuckDuckGo): https://duckduckgo.com/?q=Garoa+Hacker+Clube
+.. _Coding Dojo: https://duckduckgo.com/?q=Coding+Dojo
+.. _fotos: https://www.facebook.com/GaroaHC/photos_stream

--- a/content/episodes/051-edicao-de-2-anos-og-maciel-red-hat.rst
+++ b/content/episodes/051-edicao-de-2-anos-og-maciel-red-hat.rst
@@ -23,26 +23,23 @@ online ou e-mails em listas de discussões... enfim, um podcast "bom para
 castálio"! Passados 50 episódios, no dia 16 de fevereiro este projeto
 completou **2 anos de vida**!
 
-Para comemorar este nosso marco histórico, resolvi atender os pedidos de
-alguns ouvintes e tentar novamente publicar uma entrevista comigo mesmo!
-Para as pessoas que acompanham o podcast, vocês devem se lembrar que o
-nosso `episódio piloto <http://bit.ly/12YS1pU>`__ foi comigo também,
-numa época onde ainda estávamos explorando um formato e testando as
-tecnologias que iríamos usar. Naquela época nem existia o Top 5 ainda!
-Então, uma vez que decidi fazer a entrevista "Part 2", eu precisava
-encontrar alguém para me entrevistar, já que o Evandro não participa
-desde o terceiro episódio. Duas pessoas se prontificaram a desempenhar
-este papel, todos eles amigos que me conhecem há alguns anos e mais que
-capazes de fazer perguntas interessantes... e no final eu pedi ao meu
-amigo **KurtKraut** (que já foi entrevistado
-`aqui <http://bit.ly/VAfGLG>`__) para me entrevistar.
+Para comemorar este nosso marco histórico, resolvi atender os pedidos de alguns
+ouvintes e tentar novamente publicar uma entrevista comigo mesmo!  Para as
+pessoas que acompanham o podcast, vocês devem se lembrar que o nosso `episódio
+piloto`_ foi comigo também, numa época onde ainda estávamos explorando um
+formato e testando as tecnologias que iríamos usar. Naquela época nem existia
+o Top 5 ainda!  Então, uma vez que decidi fazer a entrevista "Part 2", eu
+precisava encontrar alguém para me entrevistar, já que o Evandro não participa
+desde o terceiro episódio. Duas pessoas se prontificaram a desempenhar este
+papel, todos eles amigos que me conhecem há alguns anos e mais que capazes de
+fazer perguntas interessantes... e no final eu pedi ao meu amigo **KurtKraut**
+(que já foi entrevistado `aqui`_) para me entrevistar.
 
-O nosso bate-papo, que foi publicado ao vivo pelo
-`Youtube <http://bit.ly/12MJKVZ>`__, rolou por mais de 1 hora, e durante
-estes 60+ minutos conversamos sobre a origem do meu nome, como que eu
-vim parar nos Estados Unidos há 21 anos atrás, minha carreira como
-programador, minha vinda para a Carolina do Norte, sobre o Ubuntu,
-compilando kernels, trabalhando na Red Hat, privacidade, e meu Top 5!
+O nosso bate-papo, que foi publicado ao vivo pelo `Youtube`_, rolou por mais
+de 1 hora, e durante estes 60+ minutos conversamos sobre a origem do meu nome,
+como que eu vim parar nos Estados Unidos há 21 anos atrás, minha carreira como
+programador, minha vinda para a Carolina do Norte, sobre o Ubuntu, compilando
+kernels, trabalhando na Red Hat, privacidade, e meu Top 5!
 
 .. more
 
@@ -75,82 +72,82 @@ Contato
 
 Top 5
 -----
--  **Música:** `Legião Urbana <http://www.last.fm/search?q=Legião+Urbana>`__
--  **Música:** `Os Paralamas do Sucesso <http://www.last.fm/search?q=Os+Paralamas+do+Sucesso>`__
--  **Música:** `Ultraje a Rigor <http://www.last.fm/search?q=Ultraje+a+Rigor>`__
--  **Música:** `Titãs <http://www.last.fm/search?q=Titãs>`__
--  **Música:** `Barão Vermelho <http://www.last.fm/search?q=Barão+Vermelho>`__
--  **Música:** `Capital Inicial <http://www.last.fm/search?q=Capital+Inicial>`__
--  **Música:** `Dire Straits <http://www.last.fm/search?q=Dire+Straits>`__
--  **Música:** `Pink Floyd <http://www.last.fm/search?q=Pink+Floyd>`__
--  **Música:** `Led Zeppelin <http://www.last.fm/search?q=Led+Zeppelin>`__
--  **Música:** `The Doors <http://www.last.fm/search?q=The+Doors>`__
--  **Música:** `The Cure <http://www.last.fm/search?q=The+Cure>`__
--  **Filmes:** `Blade Runner <http://www.imdb.com/find?s=all&q=Blade+Runner>`__
--  **Filmes:** `The Good, The Bad and The Ugly <http://www.imdb.com/find?s=all&q=The+Good,+The+Bad+and+The+Ugly>`__
--  **Filmes:** `Beau Geste <http://www.imdb.com/find?s=all&q=Beau+Geste>`__
--  **Filmes:** `Sessão da Tarde <http://www.imdb.com/find?s=all&q=Sessão+da+Tarde>`__
--  **Filmes:** `Os Trapalhões <http://www.imdb.com/find?s=all&q=Os+Trapalhões>`__
--  **Filmes:** `Pulp Fiction <http://www.imdb.com/find?s=all&q=Pulp+Fiction>`__
--  **Filmes:** `Snatch <http://www.imdb.com/find?s=all&q=Snatch>`__
--  **Filmes:** `Syriana <http://www.imdb.com/find?s=all&q=Syriana>`__
--  **Filmes:** `Ides of March <http://www.imdb.com/find?s=all&q=Ides+of+March>`__
--  **Livros:** `Maria José Dupré <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Maria+José+Dupré>`__
--  **Livros:** `O Cachorrinho Samba <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=O+Cachorrinho+Samba>`__
--  **Livros:** `A Mina de Ouro <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=A+Mina+de+Ouro>`__
--  **Livros:** `A Montanha Encantada <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=A+Montanha+Encantada>`__
--  **Livros:** `Monteiro Lobato <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Monteiro+Lobato>`__
--  **Livros:** `Série Vagalume <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Série+Vagalume>`__
--  **Livros:** `Sítio do Picapau Amarelo <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Sítio+do+Picapau+Amarelo>`__
--  **Livros:** `Issac Asimov <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Issac+Asimov>`__
--  **Livros:** `Jules Verne <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Jules+Verne>`__
--  **Livros:** `Homero <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Homero>`__
--  **Livros:** `A Odisséia <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=A+Odisséia>`__
--  **Livros:** `Mark Twain <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Mark+Twain>`__
--  **Livros:** `Tom Sawyer <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Tom+Sawyer>`__
--  **Livros:** `Edgar Alan Poe <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Edgar+Alan+Poe>`__
--  **Livros:** `Kit Carson <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Kit+Carson>`__
--  **Software:** `vim <http://www.vim.org/>`__
--  **Software:** `emacs <https://www.gnu.org/software/emacs>`__
--  **Software:** `openbox <http://openbox.org/>`__
--  **Software:** `i3 <http://i3wm.org/>`__
--  **Software:** `ipython <http://ipython.org/>`__
--  **Software:** `terminator <http://www.tenshu.net/p/terminator.html>`__
--  **Software:** `git <http://git-scm.com/>`__
+-  **Música:** `Legião Urbana`_
+-  **Música:** `Os Paralamas do Sucesso`_
+-  **Música:** `Ultraje a Rigor`_
+-  **Música:** `Titãs`_
+-  **Música:** `Barão Vermelho`_
+-  **Música:** `Capital Inicial`_
+-  **Música:** `Dire Straits`_
+-  **Música:** `Pink Floyd`_
+-  **Música:** `Led Zeppelin`_
+-  **Música:** `The Doors`_
+-  **Música:** `The Cure`_
+-  **Filmes:** `Blade Runner`_
+-  **Filmes:** `The Good, The Bad and The Ugly`_
+-  **Filmes:** `Beau Geste`_
+-  **Filmes:** `Sessão da Tarde`_
+-  **Filmes:** `Os Trapalhões`_
+-  **Filmes:** `Pulp Fiction`_
+-  **Filmes:** `Snatch`_
+-  **Filmes:** `Syriana`_
+-  **Filmes:** `Ides of March`_
+-  **Livros:** `Maria José Dupré`_
+-  **Livros:** `O Cachorrinho Samba`_
+-  **Livros:** `A Mina de Ouro`_
+-  **Livros:** `A Montanha Encantada`_
+-  **Livros:** `Monteiro Lobato`_
+-  **Livros:** `Série Vagalume`_
+-  **Livros:** `Sítio do Picapau Amarelo`_
+-  **Livros:** `Issac Asimov`_
+-  **Livros:** `Jules Verne`_
+-  **Livros:** `Homero`_
+-  **Livros:** `A Odisséia`_
+-  **Livros:** `Mark Twain`_
+-  **Livros:** `Tom Sawyer`_
+-  **Livros:** `Edgar Alan Poe`_
+-  **Livros:** `Kit Carson`_
+-  **Software:** `vim`_
+-  **Software:** `emacs`_
+-  **Software:** `Openbox`_
+-  **Software:** `i3`_
+-  **Software:** `ipython`_
+-  **Software:** `terminator`_
+-  **Software:** `git`_
 
 Links
 -----
--  `Og Mandino <https://duckduckgo.com/?q=Og+Mandino>`__
--  `Fernando Collor de Mello <https://duckduckgo.com/?q=Fernando+Collor+de+Mello>`__
--  `rPath <https://duckduckgo.com/?q=rPath>`__
--  `Red Hat <https://duckduckgo.com/?q=Red+Hat>`__
--  `Visual Basic <https://duckduckgo.com/?q=Visual+Basic>`__
--  `PL/SQL <https://duckduckgo.com/?q=PL/SQL>`__
--  `Oracle <https://duckduckgo.com/?q=Oracle>`__
--  `.NET <https://duckduckgo.com/?q=.NET>`__
--  `Richard Stallman <https://duckduckgo.com/?q=Richard+Stallman>`__
--  `Slackware Linux <https://duckduckgo.com/?q=Slackware+Linux>`__
--  `Gentoo Linux <https://duckduckgo.com/?q=Gentoo+Linux>`__
--  `Fedora Linux <https://duckduckgo.com/?q=Fedora+Linux>`__
--  `Github <https://duckduckgo.com/?q=Github>`__
--  `Bitbucket <https://duckduckgo.com/?q=Bitbucket>`__
--  `Google Reader <https://duckduckgo.com/?q=Google+Reader>`__
--  `Twitter <https://duckduckgo.com/?q=Twitter>`__
--  `Ubuntu Brasil <https://duckduckgo.com/?q=Ubuntu+Brasil>`__
--  `Ubuntu Linux <https://duckduckgo.com/?q=Ubuntu+Linux>`__
--  `Foresight Linux <https://duckduckgo.com/?q=Foresight+Linux>`__
--  `GNOME <https://duckduckgo.com/?q=GNOME>`__
--  `Ubuntu UDS <https://duckduckgo.com/?q=Ubuntu+UDS>`__
--  `IRC <https://duckduckgo.com/?q=IRC>`__
--  `Xfce <https://duckduckgo.com/?q=Xfce>`__
--  `LXDE <https://duckduckgo.com/?q=LXDE>`__
--  `Openbox <https://duckduckgo.com/?q=Openbox>`__
--  `Fabiano Fidêncio <https://duckduckgo.com/?q=Fabiano+Fidêncio>`__
--  `Google Summer of Code <https://duckduckgo.com/?q=Google+Summer+of+Code>`__
--  `Miguel de Icaza <https://duckduckgo.com/?q=Miguel+de+Icaza>`__
--  `Python <https://duckduckgo.com/?q=Python>`__
--  `Selenium <https://duckduckgo.com/?q=Selenium>`__
--  `SCRUM <https://duckduckgo.com/?q=SCRUM>`__
+-  `Og Mandino`_
+-  `Fernando Collor de Mello`_
+-  `rPath`_
+-  `Red Hat`_
+-  `Visual Basic`_
+-  `PL/SQL`_
+-  `Oracle`_
+-  `.NET`_
+-  `Richard Stallman`_
+-  `Slackware Linux`_
+-  `Gentoo Linux`_
+-  `Fedora Linux`_
+-  `Github`_
+-  `Bitbucket`_
+-  `Google Reader`_
+-  `Twitter`_
+-  `Ubuntu Brasil`_
+-  `Ubuntu Linux`_
+-  `Foresight Linux`_
+-  `GNOME`_
+-  `Ubuntu UDS`_
+-  `IRC`_
+-  `Xfce`_
+-  `LXDE`_
+-  `Openbox`_
+-  `Fabiano Fidêncio`_
+-  `Google Summer of Code`_
+-  `Miguel de Icaza`_
+-  `Python`_
+-  `Selenium`_
+-  `SCRUM`_
 
 .. class:: panel-body bg-info
 
@@ -159,3 +156,78 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _episódio piloto: http://bit.ly/12YS1pU
+.. _aqui: http://bit.ly/VAfGLG
+.. _Youtube: http://bit.ly/12MJKVZ
+.. _Legião Urbana: http://www.last.fm/search?q=Legião+Urbana
+.. _Os Paralamas do Sucesso: http://www.last.fm/search?q=Os+Paralamas+do+Sucesso
+.. _Ultraje a Rigor: http://www.last.fm/search?q=Ultraje+a+Rigor
+.. _Titãs: http://www.last.fm/search?q=Titãs
+.. _Barão Vermelho: http://www.last.fm/search?q=Barão+Vermelho
+.. _Capital Inicial: http://www.last.fm/search?q=Capital+Inicial
+.. _Dire Straits: http://www.last.fm/search?q=Dire+Straits
+.. _Pink Floyd: http://www.last.fm/search?q=Pink+Floyd
+.. _Led Zeppelin: http://www.last.fm/search?q=Led+Zeppelin
+.. _The Doors: http://www.last.fm/search?q=The+Doors
+.. _The Cure: http://www.last.fm/search?q=The+Cure
+.. _Blade Runner: http://www.imdb.com/find?s=all&q=Blade+Runner
+.. _The Good, The Bad and The Ugly: http://www.imdb.com/find?s=all&q=The+Good,+The+Bad+and+The+Ugly
+.. _Beau Geste: http://www.imdb.com/find?s=all&q=Beau+Geste
+.. _Sessão da Tarde: http://www.imdb.com/find?s=all&q=Sessão+da+Tarde
+.. _Os Trapalhões: http://www.imdb.com/find?s=all&q=Os+Trapalhões
+.. _Pulp Fiction: http://www.imdb.com/find?s=all&q=Pulp+Fiction
+.. _Snatch: http://www.imdb.com/find?s=all&q=Snatch
+.. _Syriana: http://www.imdb.com/find?s=all&q=Syriana
+.. _Ides of March: http://www.imdb.com/find?s=all&q=Ides+of+March
+.. _Maria José Dupré: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Maria+José+Dupré
+.. _O Cachorrinho Samba: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=O+Cachorrinho+Samba
+.. _A Mina de Ouro: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=A+Mina+de+Ouro
+.. _A Montanha Encantada: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=A+Montanha+Encantada
+.. _Monteiro Lobato: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Monteiro+Lobato
+.. _Série Vagalume: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Série+Vagalume
+.. _Sítio do Picapau Amarelo: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Sítio+do+Picapau+Amarelo
+.. _Issac Asimov: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Issac+Asimov
+.. _Jules Verne: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Jules+Verne
+.. _Homero: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Homero
+.. _A Odisséia: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=A+Odisséia
+.. _Mark Twain: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Mark+Twain
+.. _Tom Sawyer: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Tom+Sawyer
+.. _Edgar Alan Poe: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Edgar+Alan+Poe
+.. _Kit Carson: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Kit+Carson
+.. _vim: http://www.vim.org/
+.. _emacs: https://www.gnu.org/software/emacs
+.. _Openbox: http://openbox.org/
+.. _i3: http://i3wm.org/
+.. _ipython: http://ipython.org/
+.. _terminator: http://www.tenshu.net/p/terminator.html
+.. _git: http://git-scm.com/
+.. _Og Mandino: https://duckduckgo.com/?q=Og+Mandino
+.. _Fernando Collor de Mello: https://duckduckgo.com/?q=Fernando+Collor+de+Mello
+.. _rPath: https://duckduckgo.com/?q=rPath
+.. _Red Hat: https://duckduckgo.com/?q=Red+Hat
+.. _Visual Basic: https://duckduckgo.com/?q=Visual+Basic
+.. _PL/SQL: https://duckduckgo.com/?q=PL/SQL
+.. _Oracle: https://duckduckgo.com/?q=Oracle
+.. _.NET: https://duckduckgo.com/?q=.NET
+.. _Richard Stallman: https://duckduckgo.com/?q=Richard+Stallman
+.. _Slackware Linux: https://duckduckgo.com/?q=Slackware+Linux
+.. _Gentoo Linux: https://duckduckgo.com/?q=Gentoo+Linux
+.. _Fedora Linux: https://duckduckgo.com/?q=Fedora+Linux
+.. _Github: https://duckduckgo.com/?q=Github
+.. _Bitbucket: https://duckduckgo.com/?q=Bitbucket
+.. _Google Reader: https://duckduckgo.com/?q=Google+Reader
+.. _Twitter: https://duckduckgo.com/?q=Twitter
+.. _Ubuntu Brasil: https://duckduckgo.com/?q=Ubuntu+Brasil
+.. _Ubuntu Linux: https://duckduckgo.com/?q=Ubuntu+Linux
+.. _Foresight Linux: https://duckduckgo.com/?q=Foresight+Linux
+.. _GNOME: https://duckduckgo.com/?q=GNOME
+.. _Ubuntu UDS: https://duckduckgo.com/?q=Ubuntu+UDS
+.. _IRC: https://duckduckgo.com/?q=IRC
+.. _Xfce: https://duckduckgo.com/?q=Xfce
+.. _LXDE: https://duckduckgo.com/?q=LXDE
+.. _Fabiano Fidêncio: https://duckduckgo.com/?q=Fabiano+Fidêncio
+.. _Google Summer of Code: https://duckduckgo.com/?q=Google+Summer+of+Code
+.. _Miguel de Icaza: https://duckduckgo.com/?q=Miguel+de+Icaza
+.. _Python: https://duckduckgo.com/?q=Python
+.. _Selenium: https://duckduckgo.com/?q=Selenium
+.. _SCRUM: https://duckduckgo.com/?q=SCRUM

--- a/content/episodes/052-alexandre-gaigalas-yahoo.rst
+++ b/content/episodes/052-alexandre-gaigalas-yahoo.rst
@@ -12,33 +12,29 @@ Alexandre Gaigalas: Yahoo
 
    Alexandre Gaigalas: Yahoo
 
-Seja bem-vindo à mais um episódio, desta vez com o `Alexandre
-Gaigalas <http://about.me/alganet>`__ que trabalha como **engenheiro de
-software** da **Yahoo** no Brasil! Durante nosso bate-papo conversamos
-sobre o que ele faz na Yahoo, em quais projetos que trabalha, e acabei
-descobrindo que ele é mais um exemplo de uma pessoa que teve seu
-trabalho perante uma comunidade de software livre reconhecido, levando-o
-a ser indicado para trabalhar em uma companhia de nome! Conversamos
-sobre o recente anúncio que a **CEO** `Marissa
-Mayer <https://en.wikipedia.org/wiki/Marissa_Mayer>`__ fez, declatando
-que não se poderá mais trabalhar remotamente na Yahoo, sobre o efeito
-que isso teve na moral dos empregados, e como que a sua vinda está
-transformando a companhia em uma empresa mais moderna e com mais atenção
-à qualidade de seus produtos e bem-estar de seus empregados.
+Seja bem-vindo à mais um episódio, desta vez com o `Alexandre Gaigalas`_ que
+trabalha como **engenheiro de software** da **Yahoo** no Brasil! Durante nosso
+bate-papo conversamos sobre o que ele faz na Yahoo, em quais projetos que
+trabalha, e acabei descobrindo que ele é mais um exemplo de uma pessoa que teve
+seu trabalho perante uma comunidade de software livre reconhecido, levando-o
+a ser indicado para trabalhar em uma companhia de nome! Conversamos sobre
+o recente anúncio que a **CEO** `Marissa Mayer`_ fez, declatando que não se
+poderá mais trabalhar remotamente na Yahoo, sobre o efeito que isso teve na
+moral dos empregados, e como que a sua vinda está transformando a companhia em
+uma empresa mais moderna e com mais atenção à qualidade de seus produtos
+e bem-estar de seus empregados.
 
 Mais uma coisa bacana que aconteceu durante a gravação foi um commit que
-o Alexandre fez ao-vivo para o código do **Respect Doc** em
-`homenagem <https://github.com/Respect/Doc/commit/c1b6a473c62253725321eeb4a4125e3c25e709f1>`__
-ao podcast! :)
+o Alexandre fez ao-vivo para o código do **Respect Doc** em `homenagem`_ ao
+podcast! :)
 
 .. more
 
 Também falamos de programação **RESTful**, **web semântica**, o `Respect
-Project <http://respect.li/>`__ e seu **Top 5**!
+Project`_ e seu **Top 5**!
 
-Agradeço ao `Rafael Rosa Fu <https://twitter.com/rafaelrosafu>`__ do
-`GrokPodcast <http://grokpodcast.com/>`__ e o `Daniel
-Lima <https://twitter.com/yourwebmaker>`__ por enviarem suas perguntas!
+Agradeço ao `Rafael Rosa Fu`_ do `GrokPodcast`_ e o `Daniel Lima`_ por
+enviarem suas perguntas!
 
 
 Contato
@@ -50,7 +46,7 @@ Contato
 -  **Github**:  https://github.com/alganet
 -  **Last.fm**:  http://www.last.fm/user/alganet
 -  **Flickr**:  http://www.flickr.com/people/gaigalas/
--  **InfoQ**: `Dados na Web Semântica: padrões e ferramentas <http://www.infoq.com/br/presentations/web-semantica-dados;jsessionid=E408164E3C4277902ADA1D8782C45380>`__
+-  **InfoQ**: `Dados na Web Semântica\: padrões e ferramentas`_
 
 Escute Agora
 ------------
@@ -59,79 +55,79 @@ Escute Agora
 
 Top 5
 -----
--  **Música:** `Mamonas Assassinas <http://www.last.fm/search?q=Mamonas+Assassinas>`__
--  **Música:** `Megadeth <http://www.last.fm/search?q=Megadeth>`__
--  **Música:** `Shadow Gallery <http://www.last.fm/search?q=Shadow+Gallery>`__
--  **Filmes:** `Breaking Bad <http://www.imdb.com/find?s=all&q=Breaking+Bad>`__
--  **Filmes:** `Dexter <http://www.imdb.com/find?s=all&q=Dexter>`__
--  **Filmes:** `Top Gear <http://www.imdb.com/find?s=all&q=Top+Gear>`__
--  **Filmes:** `Mad Men <http://www.imdb.com/find?s=all&q=Mad+Men>`__
--  **Livros:** `The Lean Startup <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=The+Lean+Startup>`__
--  **Livros:** `Programação Extrema Explicada <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Programação+Extrema+Explicada>`__
--  **Livros:** `Vinícius Magalhães Peres <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Vinícius+Magalhães+Peres>`__
--  **Livros:** `Deus, Um Delírio <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Deus,+Um+Delírio>`__
--  **Livros:** `Richard Dawkins <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Richard+Dawkins>`__
--  **Livros:** `Os Jogos da Vida <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Os+Jogos+da+Vida>`__
--  **Software:** `Sublime Text <https://duckduckgo.com/?q=Sublime+Text>`__
--  **Software:** `Ubuntu Linux <https://duckduckgo.com/?q=Ubuntu+Linux>`__
--  **Software:** `Firefox <https://duckduckgo.com/?q=Firefox>`__
--  **Software:** `Visual Studio 2012 <https://duckduckgo.com/?q=Visual+Studio+2012>`__
--  **Software:** `Windows Poer Shell <https://duckduckgo.com/?q=Windows+Poer+Shell>`__
+-  **Música:** `Mamonas Assassinas`_
+-  **Música:** `Megadeth`_
+-  **Música:** `Shadow Gallery`_
+-  **Filmes:** `Breaking Bad`_
+-  **Filmes:** `Dexter`_
+-  **Filmes:** `Top Gear`_
+-  **Filmes:** `Mad Men`_
+-  **Livros:** `The Lean Startup`_
+-  **Livros:** `Programação Extrema Explicada`_
+-  **Livros:** `Vinícius Magalhães Peres`_
+-  **Livros:** `Deus, Um Delírio`_
+-  **Livros:** `Richard Dawkins`_
+-  **Livros:** `Os Jogos da Vida`_
+-  **Software:** `Sublime Text`_
+-  **Software:** `Ubuntu Linux`_
+-  **Software:** `Firefox`_
+-  **Software:** `Visual Studio 2012`_
+-  **Software:** `Windows Poer Shell`_
 
 Links
 -----
--  `Yahoo <https://duckduckgo.com/?q=Yahoo>`__
--  `Yahoo Memo <https://duckduckgo.com/?q=Yahoo+Memo>`__
--  `Yahoo Profile <https://duckduckgo.com/?q=Yahoo+Profile>`__
--  `Yahoo Mail <https://duckduckgo.com/?q=Yahoo+Mail>`__
--  `Windows 8 <https://duckduckgo.com/?q=Windows+8>`__
--  `Java Script <https://duckduckgo.com/?q=Java+Script>`__
--  `Github <https://duckduckgo.com/?q=Github>`__
--  `Selenium <https://duckduckgo.com/?q=Selenium>`__
--  `Internet Explorer <https://duckduckgo.com/?q=Internet+Explorer>`__
--  `NodeJS <https://duckduckgo.com/?q=NodeJS>`__
--  `Web Socket <https://duckduckgo.com/?q=Web+Socket>`__
--  `Safary Web Browser <https://duckduckgo.com/?q=Safary+Web+Browser>`__
--  `Firefox Web Browser <https://duckduckgo.com/?q=Firefox+Web+Browser>`__
--  `CSS <https://duckduckgo.com/?q=CSS>`__
--  `PHP <https://duckduckgo.com/?q=PHP>`__
--  `Android <https://duckduckgo.com/?q=Android>`__
--  `Grok Podcast <https://duckduckgo.com/?q=Grok+Podcast>`__
--  `Rafael Rosa Fu <https://duckduckgo.com/?q=Rafael+Rosa+Fu>`__
--  `Marissa Meyer <https://duckduckgo.com/?q=Marissa+Meyer>`__
--  `Google Search <https://duckduckgo.com/?q=Google+Search>`__
--  `Google Maps <https://duckduckgo.com/?q=Google+Maps>`__
--  `Daniel Lima <https://duckduckgo.com/?q=Daniel+Lima>`__
--  `RestFul <https://duckduckgo.com/?q=RestFul>`__
--  `Web Semântica <https://duckduckgo.com/?q=Web+Semântica>`__
--  `HTTP <https://duckduckgo.com/?q=HTTP>`__
--  `Tableless <https://duckduckgo.com/?q=Tableless>`__
--  `Rails Framework <https://duckduckgo.com/?q=Rails+Framework>`__
--  `Django Framework <https://duckduckgo.com/?q=Django+Framework>`__
--  `CakePHP <https://duckduckgo.com/?q=CakePHP>`__
--  `RFC1626 <https://duckduckgo.com/?q=RFC1626>`__
--  `HTML <https://duckduckgo.com/?q=HTML>`__
--  `RDF <https://duckduckgo.com/?q=RDF>`__
--  `XML Schema <https://duckduckgo.com/?q=XML+Schema>`__
--  `InfoQ <https://duckduckgo.com/?q=InfoQ>`__
--  `Formato JSON <https://duckduckgo.com/?q=Formato+JSON>`__
--  `Formato Atom <https://duckduckgo.com/?q=Formato+Atom>`__
--  `Respect Project <https://duckduckgo.com/?q=Respect+Project>`__
--  `Editor Vim <https://duckduckgo.com/?q=Editor+Vim>`__
--  `Editor Nano <https://duckduckgo.com/?q=Editor+Nano>`__
--  `Respect Rest <https://duckduckgo.com/?q=Respect+Rest>`__
--  `PHP Engine <https://duckduckgo.com/?q=PHP+Engine>`__
--  `Respect Config <https://duckduckgo.com/?q=Respect+Config>`__
--  `Dependency Injection <https://duckduckgo.com/?q=Dependency+Injection>`__
--  `Respect Doc <https://duckduckgo.com/?q=Respect+Doc>`__
--  `PHP Documenter <https://duckduckgo.com/?q=PHP+Documenter>`__
--  `Cygwin <https://duckduckgo.com/?q=Cygwin>`__
--  `Firebug <https://duckduckgo.com/?q=Firebug>`__
--  `DOM Inspector <https://duckduckgo.com/?q=DOM+Inspector>`__
--  `Netflix <https://duckduckgo.com/?q=Netflix>`__
--  `House of Cards <https://duckduckgo.com/?q=House+of+Cards>`__
--  `Metodologia Ágil <https://duckduckgo.com/?q=Metodologia+Ágil>`__
--  `William Sanders <https://duckduckgo.com/?q=William+Sanders>`__
+-  `Yahoo`_
+-  `Yahoo Memo`_
+-  `Yahoo Profile`_
+-  `Yahoo Mail`_
+-  `Windows 8`_
+-  `Java Script`_
+-  `Github`_
+-  `Selenium`_
+-  `Internet Explorer`_
+-  `NodeJS`_
+-  `Web Socket`_
+-  `Safary Web Browser`_
+-  `Firefox Web Browser`_
+-  `CSS`_
+-  `PHP`_
+-  `Android`_
+-  `Grok Podcast`_
+-  `Rafael Rosa Fu (DuckDuckGo)`_
+-  `Marissa Meyer`_
+-  `Google Search`_
+-  `Google Maps`_
+-  `Daniel Lima (DuckDuckGo)`_
+-  `RestFul`_
+-  `Web Semântica`_
+-  `HTTP`_
+-  `Tableless`_
+-  `Rails Framework`_
+-  `Django Framework`_
+-  `CakePHP`_
+-  `RFC1626`_
+-  `HTML`_
+-  `RDF`_
+-  `XML Schema`_
+-  `InfoQ`_
+-  `Formato JSON`_
+-  `Formato Atom`_
+-  `Respect Project (DuckDuckGo)`_
+-  `Editor Vim`_
+-  `Editor Nano`_
+-  `Respect Rest`_
+-  `PHP Engine`_
+-  `Respect Config`_
+-  `Dependency Injection`_
+-  `Respect Doc`_
+-  `PHP Documenter`_
+-  `Cygwin`_
+-  `Firebug`_
+-  `DOM Inspector`_
+-  `Netflix`_
+-  `House of Cards`_
+-  `Metodologia Ágil`_
+-  `William Sanders`_
 
 .. class:: panel-body bg-info
 
@@ -140,3 +136,81 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _Alexandre Gaigalas: http://about.me/alganet
+.. _Marissa Mayer: https://en.wikipedia.org/wiki/Marissa_Mayer
+.. _homenagem: https://github.com/Respect/Doc/commit/c1b6a473c62253725321eeb4a4125e3c25e709f1
+.. _Respect Project: http://respect.li/
+.. _Rafael Rosa Fu: https://twitter.com/rafaelrosafu
+.. _GrokPodcast: http://grokpodcast.com/
+.. _Dados na Web Semântica\: padrões e ferramentas: http://www.infoq.com/br/presentations/web-semantica-dados;jsessionid=E408164E3C4277902ADA1D8782C45380
+.. _Mamonas Assassinas: http://www.last.fm/search?q=Mamonas+Assassinas
+.. _Megadeth: http://www.last.fm/search?q=Megadeth
+.. _Shadow Gallery: http://www.last.fm/search?q=Shadow+Gallery
+.. _Breaking Bad: http://www.imdb.com/find?s=all&q=Breaking+Bad
+.. _Dexter: http://www.imdb.com/find?s=all&q=Dexter
+.. _Top Gear: http://www.imdb.com/find?s=all&q=Top+Gear
+.. _Mad Men: http://www.imdb.com/find?s=all&q=Mad+Men
+.. _The Lean Startup: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=The+Lean+Startup
+.. _Programação Extrema Explicada: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Programação+Extrema+Explicada
+.. _Vinícius Magalhães Peres: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Vinícius+Magalhães+Peres
+.. _Deus, Um Delírio: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Deus,+Um+Delírio
+.. _Richard Dawkins: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Richard+Dawkins
+.. _Os Jogos da Vida: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Os+Jogos+da+Vida
+.. _Sublime Text: https://duckduckgo.com/?q=Sublime+Text
+.. _Ubuntu Linux: https://duckduckgo.com/?q=Ubuntu+Linux
+.. _Firefox: https://duckduckgo.com/?q=Firefox
+.. _Visual Studio 2012: https://duckduckgo.com/?q=Visual+Studio+2012
+.. _Windows Poer Shell: https://duckduckgo.com/?q=Windows+Poer+Shell
+.. _Yahoo: https://duckduckgo.com/?q=Yahoo
+.. _Yahoo Memo: https://duckduckgo.com/?q=Yahoo+Memo
+.. _Yahoo Profile: https://duckduckgo.com/?q=Yahoo+Profile
+.. _Yahoo Mail: https://duckduckgo.com/?q=Yahoo+Mail
+.. _Windows 8: https://duckduckgo.com/?q=Windows+8
+.. _Java Script: https://duckduckgo.com/?q=Java+Script
+.. _Github: https://duckduckgo.com/?q=Github
+.. _Selenium: https://duckduckgo.com/?q=Selenium
+.. _Internet Explorer: https://duckduckgo.com/?q=Internet+Explorer
+.. _NodeJS: https://duckduckgo.com/?q=NodeJS
+.. _Web Socket: https://duckduckgo.com/?q=Web+Socket
+.. _Safary Web Browser: https://duckduckgo.com/?q=Safary+Web+Browser
+.. _Firefox Web Browser: https://duckduckgo.com/?q=Firefox+Web+Browser
+.. _CSS: https://duckduckgo.com/?q=CSS
+.. _PHP: https://duckduckgo.com/?q=PHP
+.. _Android: https://duckduckgo.com/?q=Android
+.. _Grok Podcast: https://duckduckgo.com/?q=Grok+Podcast
+.. _Rafael Rosa Fu (DuckDuckGo): https://duckduckgo.com/?q=Rafael+Rosa+Fu
+.. _Marissa Meyer: https://duckduckgo.com/?q=Marissa+Meyer
+.. _Google Search: https://duckduckgo.com/?q=Google+Search
+.. _Google Maps: https://duckduckgo.com/?q=Google+Maps
+.. _Daniel Lima (DuckDuckGo): https://duckduckgo.com/?q=Daniel+Lima
+.. _RestFul: https://duckduckgo.com/?q=RestFul
+.. _Web Semântica: https://duckduckgo.com/?q=Web+Semântica
+.. _HTTP: https://duckduckgo.com/?q=HTTP
+.. _Tableless: https://duckduckgo.com/?q=Tableless
+.. _Rails Framework: https://duckduckgo.com/?q=Rails+Framework
+.. _Django Framework: https://duckduckgo.com/?q=Django+Framework
+.. _CakePHP: https://duckduckgo.com/?q=CakePHP
+.. _RFC1626: https://duckduckgo.com/?q=RFC1626
+.. _HTML: https://duckduckgo.com/?q=HTML
+.. _RDF: https://duckduckgo.com/?q=RDF
+.. _XML Schema: https://duckduckgo.com/?q=XML+Schema
+.. _InfoQ: https://duckduckgo.com/?q=InfoQ
+.. _Formato JSON: https://duckduckgo.com/?q=Formato+JSON
+.. _Formato Atom: https://duckduckgo.com/?q=Formato+Atom
+.. _Respect Project (DuckDuckGo): https://duckduckgo.com/?q=Respect+Project
+.. _Editor Vim: https://duckduckgo.com/?q=Editor+Vim
+.. _Editor Nano: https://duckduckgo.com/?q=Editor+Nano
+.. _Respect Rest: https://duckduckgo.com/?q=Respect+Rest
+.. _PHP Engine: https://duckduckgo.com/?q=PHP+Engine
+.. _Respect Config: https://duckduckgo.com/?q=Respect+Config
+.. _Dependency Injection: https://duckduckgo.com/?q=Dependency+Injection
+.. _Respect Doc: https://duckduckgo.com/?q=Respect+Doc
+.. _PHP Documenter: https://duckduckgo.com/?q=PHP+Documenter
+.. _Cygwin: https://duckduckgo.com/?q=Cygwin
+.. _Firebug: https://duckduckgo.com/?q=Firebug
+.. _DOM Inspector: https://duckduckgo.com/?q=DOM+Inspector
+.. _Netflix: https://duckduckgo.com/?q=Netflix
+.. _House of Cards: https://duckduckgo.com/?q=House+of+Cards
+.. _Metodologia Ágil: https://duckduckgo.com/?q=Metodologia+Ágil
+.. _William Sanders: https://duckduckgo.com/?q=William+Sanders
+.. _Daniel Lima: https://twitter.com/yourwebmaker

--- a/content/episodes/053-everaldo-canuto-toca-do-canuto.rst
+++ b/content/episodes/053-everaldo-canuto-toca-do-canuto.rst
@@ -19,25 +19,23 @@ se tornasse igual aquelas amizades que fazemos quando criança... aquelas
 pessoas que não importa o tempo ou a distância, você sempre fica feliz
 de encontrar e bater um papo!
 
-O Everaldo teve uma das oportunidades que eu sempre sonhei em ter:
-trabalhar lado a lado com o **Miguel de Icaza**, um dos fundadores do
-**Projeto GNOME**, figura quase que mitológica do mundo do software
-livre e hoje empresário com várias companhias de sucesso em seu
-histórico! Ele também trabalhava com a tecnologia .NET numa época quando
-qualquer coisa que fosse remotamente relacianada à Microsoft era motivo
-para perseguição e "trollage" pelos apoiadores mais zelosos do Linux.
-Durante grande parte de nosso bate-papo, conversamos sobre como que ele
-foi parar na **Novell** trabalhando para a equipe do Miguel, como era o
-dia-a-dia lidando com o sentimento anti- Microsoft, quais tecnologias
-ele recomenda para quem está começando a trabalhar na área de TI, o
-"problema" do **Java**, e sobre seu mais novo projeto,\ `Toca do
-Canuto <http://www.youtube.com/user/tocadocanuto?feature=g-subs-u>`__.
+O Everaldo teve uma das oportunidades que eu sempre sonhei em ter: trabalhar
+lado a lado com o **Miguel de Icaza**, um dos fundadores do **Projeto GNOME**,
+figura quase que mitológica do mundo do software livre e hoje empresário com
+várias companhias de sucesso em seu histórico! Ele também trabalhava com
+a tecnologia .NET numa época quando qualquer coisa que fosse remotamente
+relacianada à Microsoft era motivo para perseguição e "trollage" pelos
+apoiadores mais zelosos do Linux.  Durante grande parte de nosso bate-papo,
+conversamos sobre como que ele foi parar na **Novell** trabalhando para
+a equipe do Miguel, como era o dia-a-dia lidando com o sentimento
+anti- Microsoft, quais tecnologias ele recomenda para quem está começando
+a trabalhar na área de TI, o "problema" do **Java**, e sobre seu mais novo
+projeto, `Toca do Canuto`_.
 
 .. more
 
-Assista o `vídeo <http://bit.ly/Z8tFWJ>`__ da entrevista para ver a
-nossa conversa na íntegra, sem edição e escutar algumas coisas que não
-foram incluídas no podcast.
+Assista o `vídeo`_ da entrevista para ver a nossa conversa na íntegra, sem
+edição e escutar algumas coisas que não foram incluídas no podcast.
 
 Escute Agora
 ------------
@@ -53,64 +51,64 @@ Contato
 
 Top 5
 -----
--  **Música:** `Titãs <http://www.last.fm/search?q=Titãs>`__
--  **Música:** `Legião Urbana <http://www.last.fm/search?q=Legião+Urbana>`__
--  **Música:** `Engenheiros do Hawaii <http://www.last.fm/search?q=Engenheiros+do+Hawaii>`__
--  **Música:** `Pink Floyd <http://www.last.fm/search?q=Pink+Floyd>`__
--  **Livros:** `O Homem da Areia <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=O+Homem+da+Areia>`__
--  **Livros:** `Sir Arthur Conan Doyle <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Sir+Arthur+Conan+Doyle>`__
--  **Livros:** `Deus Um Delírio <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Deus+Um+Delírio>`__
--  **Livros:** `O Hobbit <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=O+Hobbit>`__
--  **Livros:** `O Código DaVinci <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=O+Código+DaVinci>`__
--  **Software:** `OpenSSH <https://duckduckgo.com/?q=OpenSSH>`__
--  **Software:** `Git <https://duckduckgo.com/?q=Git>`__
--  **Software:** `Markdown <https://duckduckgo.com/?q=Markdown>`__
--  **Software:** `Google Hangout <https://duckduckgo.com/?q=Google+Hangout>`__
--  **Software:** `Youtube <https://duckduckgo.com/?q=Youtube>`__
--  **Software:** `HTML 5 <https://duckduckgo.com/?q=HTML+5>`__
--  **Software:** `CSS3 <https://duckduckgo.com/?q=CSS3>`__
+-  **Música:** `Titãs`_
+-  **Música:** `Legião Urbana`_
+-  **Música:** `Engenheiros do Hawaii`_
+-  **Música:** `Pink Floyd`_
+-  **Livros:** `O Homem da Areia`_
+-  **Livros:** `Sir Arthur Conan Doyle`_
+-  **Livros:** `Deus Um Delírio`_
+-  **Livros:** `O Hobbit`_
+-  **Livros:** `O Código DaVinci`_
+-  **Software:** `OpenSSH`_
+-  **Software:** `Git`_
+-  **Software:** `Markdown`_
+-  **Software:** `Google Hangout`_
+-  **Software:** `Youtube`_
+-  **Software:** `HTML 5`_
+-  **Software:** `CSS3`_
 
 Links
 -----
--  `GUADEC <https://duckduckgo.com/?q=GUADEC>`__
--  `Intel <https://duckduckgo.com/?q=Intel>`__
--  `Moblin <https://duckduckgo.com/?q=Moblin>`__
--  `Processador Atom <https://duckduckgo.com/?q=Processador+Atom>`__
--  `Ilhas Canárias <https://duckduckgo.com/?q=Ilhas+Canárias>`__
--  `Novell <https://duckduckgo.com/?q=Novell>`__
--  `Miguel de Icaza <https://duckduckgo.com/?q=Miguel+de+Icaza>`__
--  `Projeto Ximian <https://duckduckgo.com/?q=Projeto+Ximian>`__
--  `Projeto GNOME <https://duckduckgo.com/?q=Projeto+GNOME>`__
--  `Richard Stallman <https://duckduckgo.com/?q=Richard+Stallman>`__
--  `DBASE III Plus <https://duckduckgo.com/?q=DBASE+III+Plus>`__
--  `Apache Web Server <https://duckduckgo.com/?q=Apache+Web+Server>`__
--  `PHP <https://duckduckgo.com/?q=PHP>`__
--  `Delphi <https://duckduckgo.com/?q=Delphi>`__
--  `.NET <https://duckduckgo.com/?q=.NET>`__
--  `Java <https://duckduckgo.com/?q=Java>`__
--  `Sun Corporation <https://duckduckgo.com/?q=Sun+Corporation>`__
--  `Microsoft <https://duckduckgo.com/?q=Microsoft>`__
--  `Mono <https://duckduckgo.com/?q=Mono>`__
--  `DotGNU <https://duckduckgo.com/?q=DotGNU>`__
--  `Andréia Gaita <https://duckduckgo.com/?q=Andréia+Gaita>`__
--  `Suse Linux <https://duckduckgo.com/?q=Suse+Linux>`__
--  `Xen <https://duckduckgo.com/?q=Xen>`__
--  `Nat Friedman <https://duckduckgo.com/?q=Nat+Friedman>`__
--  `Suse Studio <https://duckduckgo.com/?q=Suse+Studio>`__
--  `Windows Forms <https://duckduckgo.com/?q=Windows+Forms>`__
--  `ASP.NET <https://duckduckgo.com/?q=ASP.NET>`__
--  `Moonlight <https://duckduckgo.com/?q=Moonlight>`__
--  `Silverlight <https://duckduckgo.com/?q=Silverlight>`__
--  `ECMA <https://duckduckgo.com/?q=ECMA>`__
--  `Xamarin <https://duckduckgo.com/?q=Xamarin>`__
--  `Editor gEdit <https://duckduckgo.com/?q=Editor+gEdit>`__
--  `Editor KATE <https://duckduckgo.com/?q=Editor+KATE>`__
--  `Power Shell <https://duckduckgo.com/?q=Power+Shell>`__
--  `Toca do Canuto <https://duckduckgo.com/?q=Toca+do+Canuto>`__
--  `GTMeter <https://duckduckgo.com/?q=GTMeter>`__
--  `LoadImpact <https://duckduckgo.com/?q=LoadImpact>`__
--  `Spotify <https://duckduckgo.com/?q=Spotify>`__
--  `Pandora <https://duckduckgo.com/?q=Pandora>`__
+-  `GUADEC`_
+-  `Intel`_
+-  `Moblin`_
+-  `Processador Atom`_
+-  `Ilhas Canárias`_
+-  `Novell`_
+-  `Miguel de Icaza`_
+-  `Projeto Ximian`_
+-  `Projeto GNOME`_
+-  `Richard Stallman`_
+-  `DBASE III Plus`_
+-  `Apache Web Server`_
+-  `PHP`_
+-  `Delphi`_
+-  `.NET`_
+-  `Java`_
+-  `Sun Corporation`_
+-  `Microsoft`_
+-  `Mono`_
+-  `DotGNU`_
+-  `Andréia Gaita`_
+-  `Suse Linux`_
+-  `Xen`_
+-  `Nat Friedman`_
+-  `Suse Studio`_
+-  `Windows Forms`_
+-  `ASP.NET`_
+-  `Moonlight`_
+-  `Silverlight`_
+-  `ECMA`_
+-  `Xamarin`_
+-  `Editor gEdit`_
+-  `Editor KATE`_
+-  `Power Shell`_
+-  `Toca do Canuto (DuckDuckGo)`_
+-  `GTMeter`_
+-  `LoadImpact`_
+-  `Spotify`_
+-  `Pandora`_
 
 .. class:: panel-body bg-info
 
@@ -119,3 +117,60 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _Toca do Canuto: http://www.youtube.com/user/tocadocanuto?feature=g-subs-u
+.. _vídeo: http://bit.ly/Z8tFWJ
+.. _Titãs: http://www.last.fm/search?q=Titãs
+.. _Legião Urbana: http://www.last.fm/search?q=Legião+Urbana
+.. _Engenheiros do Hawaii: http://www.last.fm/search?q=Engenheiros+do+Hawaii
+.. _Pink Floyd: http://www.last.fm/search?q=Pink+Floyd
+.. _O Homem da Areia: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=O+Homem+da+Areia
+.. _Sir Arthur Conan Doyle: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Sir+Arthur+Conan+Doyle
+.. _Deus Um Delírio: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Deus+Um+Delírio
+.. _O Hobbit: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=O+Hobbit
+.. _O Código DaVinci: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=O+Código+DaVinci
+.. _OpenSSH: https://duckduckgo.com/?q=OpenSSH
+.. _Git: https://duckduckgo.com/?q=Git
+.. _Markdown: https://duckduckgo.com/?q=Markdown
+.. _Google Hangout: https://duckduckgo.com/?q=Google+Hangout
+.. _Youtube: https://duckduckgo.com/?q=Youtube
+.. _HTML 5: https://duckduckgo.com/?q=HTML+5
+.. _CSS3: https://duckduckgo.com/?q=CSS3
+.. _GUADEC: https://duckduckgo.com/?q=GUADEC
+.. _Intel: https://duckduckgo.com/?q=Intel
+.. _Moblin: https://duckduckgo.com/?q=Moblin
+.. _Processador Atom: https://duckduckgo.com/?q=Processador+Atom
+.. _Ilhas Canárias: https://duckduckgo.com/?q=Ilhas+Canárias
+.. _Novell: https://duckduckgo.com/?q=Novell
+.. _Miguel de Icaza: https://duckduckgo.com/?q=Miguel+de+Icaza
+.. _Projeto Ximian: https://duckduckgo.com/?q=Projeto+Ximian
+.. _Projeto GNOME: https://duckduckgo.com/?q=Projeto+GNOME
+.. _Richard Stallman: https://duckduckgo.com/?q=Richard+Stallman
+.. _DBASE III Plus: https://duckduckgo.com/?q=DBASE+III+Plus
+.. _Apache Web Server: https://duckduckgo.com/?q=Apache+Web+Server
+.. _PHP: https://duckduckgo.com/?q=PHP
+.. _Delphi: https://duckduckgo.com/?q=Delphi
+.. _.NET: https://duckduckgo.com/?q=.NET
+.. _Java: https://duckduckgo.com/?q=Java
+.. _Sun Corporation: https://duckduckgo.com/?q=Sun+Corporation
+.. _Microsoft: https://duckduckgo.com/?q=Microsoft
+.. _Mono: https://duckduckgo.com/?q=Mono
+.. _DotGNU: https://duckduckgo.com/?q=DotGNU
+.. _Andréia Gaita: https://duckduckgo.com/?q=Andréia+Gaita
+.. _Suse Linux: https://duckduckgo.com/?q=Suse+Linux
+.. _Xen: https://duckduckgo.com/?q=Xen
+.. _Nat Friedman: https://duckduckgo.com/?q=Nat+Friedman
+.. _Suse Studio: https://duckduckgo.com/?q=Suse+Studio
+.. _Windows Forms: https://duckduckgo.com/?q=Windows+Forms
+.. _ASP.NET: https://duckduckgo.com/?q=ASP.NET
+.. _Moonlight: https://duckduckgo.com/?q=Moonlight
+.. _Silverlight: https://duckduckgo.com/?q=Silverlight
+.. _ECMA: https://duckduckgo.com/?q=ECMA
+.. _Xamarin: https://duckduckgo.com/?q=Xamarin
+.. _Editor gEdit: https://duckduckgo.com/?q=Editor+gEdit
+.. _Editor KATE: https://duckduckgo.com/?q=Editor+KATE
+.. _Power Shell: https://duckduckgo.com/?q=Power+Shell
+.. _Toca do Canuto (DuckDuckGo): https://duckduckgo.com/?q=Toca+do+Canuto
+.. _GTMeter: https://duckduckgo.com/?q=GTMeter
+.. _LoadImpact: https://duckduckgo.com/?q=LoadImpact
+.. _Spotify: https://duckduckgo.com/?q=Spotify
+.. _Pandora: https://duckduckgo.com/?q=Pandora

--- a/content/episodes/054-enrico-nicoletto-rafael-ferreira-projeto-gnome.rst
+++ b/content/episodes/054-enrico-nicoletto-rafael-ferreira-projeto-gnome.rst
@@ -26,22 +26,19 @@ super legal com o Enrico e Rafael sobre como todo o processo de
 traduções, desde como eles entraram para a equipe oficial, até como
 chegaram a ser os administradores da equipe brasileira.
 
-O episódio todo ficou com um pouco mais de 30 minutos, mas para quem
-quizer assistir o `vídeo <http://bit.ly/136X3jF>`__ vocês poderão
-escutar sobre outros temas que acabaram ficando de fora na hora da
-edição (devido ao tamanho final do podcast), como seus planos para o
-futuro da equipe.
+O episódio todo ficou com um pouco mais de 30 minutos, mas para quem quizer
+assistir o `vídeo`_ vocês poderão escutar sobre outros temas que acabaram
+ficando de fora na hora da edição (devido ao tamanho final do podcast), como
+seus planos para o futuro da equipe.
 
 .. more
 
-Aproveito a oportunidade para agradecer todo o apoio que tenho recebido
-nestes últimos meses, especialmente de vocês que continuam acompanhando
-o podcast e a todo o pessoal do
-`OpenCast <http://www.ubuntero.com.br/>`__ e `Papo de
-Buteco <http://papodebuteco.net/>`__! Minha vida profissional passou por
-algumas alterações (positivas) e infelizmente meu tempo livre sofreu
-bastante, mas pretendo continuar publicando outros episódios, mas talvez
-com menos frequência.
+Aproveito a oportunidade para agradecer todo o apoio que tenho recebido nestes
+últimos meses, especialmente de vocês que continuam acompanhando o podcast
+e a todo o pessoal do `OpenCast`_ e `Papo de Buteco`_! Minha vida
+profissional passou por algumas alterações (positivas) e infelizmente meu tempo
+livre sofreu bastante, mas pretendo continuar publicando outros episódios, mas
+talvez com menos frequência.
 
 Escute Agora
 ------------
@@ -53,69 +50,69 @@ Contato
 -  **Equipe GNOME Brasil**: https://l10n.gnome.org/teams/pt_BR/
 -  **Google+**: https://plus.google.com/u/0/103658771112274596272/about
 -  **Twitter**: https://twitter.com/exawarrior
--  **Linkedin**: `br.linkedin.com/pub/dir/Enrico/Nicoletto <http://br.linkedin.com/pub/dir/Enrico/Nicoletto>`__
+-  **Linkedin**: `br.linkedin.com/pub/dir/Enrico/Nicoletto`_
 
 Top 5
 -----
--  **Música:** `The Strokes <http://www.last.fm/search?q=The+Strokes>`__
--  **Música:** `Arcade Fire <http://www.last.fm/search?q=Arcade+Fire>`__
--  **Música:** `Fala Mansa <http://www.last.fm/search?q=Fala+Mansa>`__
--  **Música:** `Quatro por Um <http://www.last.fm/search?q=Quatro+por+Um>`__
--  **Música:** `Fernandinho <http://www.last.fm/search?q=Fernandinho>`__
--  **Música:** `Bryan Adams <http://www.last.fm/search?q=Bryan+Adams>`__
--  **Música:** `Bon Jovi <http://www.last.fm/search?q=Bon+Jovi>`__
--  **Música:** `Stratovarius <http://www.last.fm/search?q=Stratovarius>`__
--  **Filmes:** `Tio Nino <http://www.imdb.com/find?s=all&q=Tio+Nino>`__
--  **Filmes:** `Uma Professora Muito Maluquinha <http://www.imdb.com/find?s=all&q=Uma+Professora+Muito+Maluquinha>`__
--  **Filmes:** `El Estudiante <http://www.imdb.com/find?s=all&q=El+Estudiante>`__
--  **Filmes:** `War Games <http://www.imdb.com/find?s=all&q=War+Games>`__
--  **Filmes:** `Blankman <http://www.imdb.com/find?s=all&q=Blankman>`__
--  **Filmes:** `Total Recall <http://www.imdb.com/find?s=all&q=Total+Recall>`__
--  **Filmes:** `Lawless <http://www.imdb.com/find?s=all&q=Lawless>`__
--  **Filmes:** `Ghost in the Shell <http://www.imdb.com/find?s=all&q=Ghost+in+the+Shell>`__
--  **Filmes:** `Trance <http://www.imdb.com/find?s=all&q=Trance>`__
--  **Filmes:** `Sexto Sentido <http://www.imdb.com/find?s=all&q=Sexto+Sentido>`__
--  **Livros:** `Biblia Sagrada <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Biblia+Sagrada>`__
--  **Livros:** `Deus Tem Um Plano Para Voce <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Deus+Tem+Um+Plano+Para+Voce>`__
--  **Livros:** `Laugh and learn : 95 ways to use humor for more effective teaching and training <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Laugh+and+learn+:+95+ways+to+use+humor+for+more+effective+teaching+and+training>`__
--  **Livros:** `How Things Work Encyclopedia <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=How+Things+Work+Encyclopedia>`__
--  **Livros:** `Sagarana <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Sagarana>`__
--  **Livros:** `O Hobbit <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=O+Hobbit>`__
--  **Livros:** `Harry Potter <http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Harry+Potter>`__
--  **Software:** `poEdit <https://duckduckgo.com/?q=poEdit>`__
--  **Software:** `Gedit <https://duckduckgo.com/?q=Gedit>`__
--  **Software:** `Open-Tran <https://duckduckgo.com/?q=Open-Tran>`__
--  **Software:** `Meld <https://duckduckgo.com/?q=Meld>`__
--  **Software:** `Decker <https://duckduckgo.com/?q=Decker>`__
--  **Software:** `Damned Lies <https://duckduckgo.com/?q=Damned+Lies>`__
--  **Software:** `Transifex <https://duckduckgo.com/?q=Transifex>`__
--  **Software:** `Launchpad <https://duckduckgo.com/?q=Launchpad>`__
--  **Software:** `Translation Toolkit <https://duckduckgo.com/?q=Translation+Toolkit>`__
--  **Software:** `Notepad++ <https://duckduckgo.com/?q=Notepad++>`__
--  **Software:** `Media Player Classic <https://duckduckgo.com/?q=Media+Player+Classic>`__
--  **Software:** `Cliente de e-mail Thunderbird <https://duckduckgo.com/?q=Cliente+de+e-mail+Thunderbird>`__
--  **Software:** `Audacity <https://duckduckgo.com/?q=Audacity>`__
--  **Software:** `Kalibre <https://duckduckgo.com/?q=Kalibre>`__
--  **Software:** `Ruby on Rails <https://duckduckgo.com/?q=Ruby+on+Rails>`__
--  **Software:** `Google Chrome <https://duckduckgo.com/?q=Google+Chrome>`__
--  **Software:** `GNOME Terminal <https://duckduckgo.com/?q=GNOME+Terminal>`__
--  **Software:** `Libre Office <https://duckduckgo.com/?q=Libre+Office>`__
--  **Software:** `GOM Player <https://duckduckgo.com/?q=GOM+Player>`__
+-  **Música:** `The Strokes`_
+-  **Música:** `Arcade Fire`_
+-  **Música:** `Fala Mansa`_
+-  **Música:** `Quatro por Um`_
+-  **Música:** `Fernandinho`_
+-  **Música:** `Bryan Adams`_
+-  **Música:** `Bon Jovi`_
+-  **Música:** `Stratovarius`_
+-  **Filmes:** `Tio Nino`_
+-  **Filmes:** `Uma Professora Muito Maluquinha`_
+-  **Filmes:** `El Estudiante`_
+-  **Filmes:** `War Games`_
+-  **Filmes:** `Blankman`_
+-  **Filmes:** `Total Recall`_
+-  **Filmes:** `Lawless`_
+-  **Filmes:** `Ghost in the Shell`_
+-  **Filmes:** `Trance`_
+-  **Filmes:** `Sexto Sentido`_
+-  **Livros:** `Biblia Sagrada`_
+-  **Livros:** `Deus Tem Um Plano Para Voce`_
+-  **Livros:** `Laugh and learn - 95 ways to use humor for more effective teaching and training`_
+-  **Livros:** `How Things Work Encyclopedia`_
+-  **Livros:** `Sagarana`_
+-  **Livros:** `O Hobbit`_
+-  **Livros:** `Harry Potter`_
+-  **Software:** `poEdit`_
+-  **Software:** `Gedit`_
+-  **Software:** `Open-Tran`_
+-  **Software:** `Meld`_
+-  **Software:** `Decker`_
+-  **Software:** `Damned Lies`_
+-  **Software:** `Transifex`_
+-  **Software:** `Launchpad`_
+-  **Software:** `Translation Toolkit`_
+-  **Software:** `Notepad++`_
+-  **Software:** `Media Player Classic`_
+-  **Software:** `Cliente de e-mail Thunderbird`_
+-  **Software:** `Audacity`_
+-  **Software:** `Kalibre`_
+-  **Software:** `Ruby on Rails`_
+-  **Software:** `Google Chrome`_
+-  **Software:** `GNOME Terminal`_
+-  **Software:** `Libre Office`_
+-  **Software:** `GOM Player`_
 
 Links
 -----
--  `Projeto GNOME <https://duckduckgo.com/?q=Projeto+GNOME>`__
--  `Damned Lies <https://duckduckgo.com/?q=Damned+Lies>`__
--  `Open-Tran <https://duckduckgo.com/?q=Open-Tran>`__
--  `LDP <https://duckduckgo.com/?q=LDP>`__
--  `Leslie Watter <https://duckduckgo.com/?q=Leslie+Watter>`__
--  `GNOME Bugzilla <https://duckduckgo.com/?q=GNOME+Bugzilla>`__
--  `Projeto KDE <https://duckduckgo.com/?q=Projeto+KDE>`__
--  `C++ <https://duckduckgo.com/?q=C++>`__
--  `Vala <https://duckduckgo.com/?q=Vala>`__
--  `Arch Linux <https://duckduckgo.com/?q=Arch+Linux>`__
--  `Papo de Buteco <https://duckduckgo.com/?q=Papo+de+Buteco>`__
--  `Open Cast <https://duckduckgo.com/?q=Open+Cast>`__
+-  `Projeto GNOME`_
+-  `Damned Lies`_
+-  `Open-Tran`_
+-  `LDP`_
+-  `Leslie Watter`_
+-  `GNOME Bugzilla`_
+-  `Projeto KDE`_
+-  `C++`_
+-  `Vala`_
+-  `Arch Linux`_
+-  `Papo de Buteco (DuckDuckGo)`_
+-  `Open Cast`_
 
 .. class:: panel-body bg-info
 
@@ -124,3 +121,63 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _vídeo: http://bit.ly/136X3jF
+.. _OpenCast: http://www.ubuntero.com.br/
+.. _br.linkedin.com/pub/dir/Enrico/Nicoletto: http://br.linkedin.com/pub/dir/Enrico/Nicoletto
+.. _The Strokes: http://www.last.fm/search?q=The+Strokes
+.. _Arcade Fire: http://www.last.fm/search?q=Arcade+Fire
+.. _Fala Mansa: http://www.last.fm/search?q=Fala+Mansa
+.. _Quatro por Um: http://www.last.fm/search?q=Quatro+por+Um
+.. _Fernandinho: http://www.last.fm/search?q=Fernandinho
+.. _Bryan Adams: http://www.last.fm/search?q=Bryan+Adams
+.. _Bon Jovi: http://www.last.fm/search?q=Bon+Jovi
+.. _Stratovarius: http://www.last.fm/search?q=Stratovarius
+.. _Tio Nino: http://www.imdb.com/find?s=all&q=Tio+Nino
+.. _Uma Professora Muito Maluquinha: http://www.imdb.com/find?s=all&q=Uma+Professora+Muito+Maluquinha
+.. _El Estudiante: http://www.imdb.com/find?s=all&q=El+Estudiante
+.. _War Games: http://www.imdb.com/find?s=all&q=War+Games
+.. _Blankman: http://www.imdb.com/find?s=all&q=Blankman
+.. _Total Recall: http://www.imdb.com/find?s=all&q=Total+Recall
+.. _Lawless: http://www.imdb.com/find?s=all&q=Lawless
+.. _Ghost in the Shell: http://www.imdb.com/find?s=all&q=Ghost+in+the+Shell
+.. _Trance: http://www.imdb.com/find?s=all&q=Trance
+.. _Sexto Sentido: http://www.imdb.com/find?s=all&q=Sexto+Sentido
+.. _Biblia Sagrada: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Biblia+Sagrada
+.. _Deus Tem Um Plano Para Voce: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Deus+Tem+Um+Plano+Para+Voce
+.. _Laugh and learn - 95 ways to use humor for more effective teaching and training: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Laugh+and+learn+:+95+ways+to+use+humor+for+more+effective+teaching+and+training
+.. _How Things Work Encyclopedia: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=How+Things+Work+Encyclopedia
+.. _Sagarana: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Sagarana
+.. _O Hobbit: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=O+Hobbit
+.. _Harry Potter: http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Dstripbooks&field-keywords=Harry+Potter
+.. _poEdit: https://duckduckgo.com/?q=poEdit
+.. _Gedit: https://duckduckgo.com/?q=Gedit
+.. _Open-Tran: https://duckduckgo.com/?q=Open-Tran
+.. _Meld: https://duckduckgo.com/?q=Meld
+.. _Decker: https://duckduckgo.com/?q=Decker
+.. _Damned Lies: https://duckduckgo.com/?q=Damned+Lies
+.. _Transifex: https://duckduckgo.com/?q=Transifex
+.. _Launchpad: https://duckduckgo.com/?q=Launchpad
+.. _Translation Toolkit: https://duckduckgo.com/?q=Translation+Toolkit
+.. _Notepad++: https://duckduckgo.com/?q=Notepad++
+.. _Media Player Classic: https://duckduckgo.com/?q=Media+Player+Classic
+.. _Cliente de e-mail Thunderbird: https://duckduckgo.com/?q=Cliente+de+e-mail+Thunderbird
+.. _Audacity: https://duckduckgo.com/?q=Audacity
+.. _Kalibre: https://duckduckgo.com/?q=Kalibre
+.. _Ruby on Rails: https://duckduckgo.com/?q=Ruby+on+Rails
+.. _Google Chrome: https://duckduckgo.com/?q=Google+Chrome
+.. _GNOME Terminal: https://duckduckgo.com/?q=GNOME+Terminal
+.. _Libre Office: https://duckduckgo.com/?q=Libre+Office
+.. _GOM Player: https://duckduckgo.com/?q=GOM+Player
+.. _Projeto GNOME: https://duckduckgo.com/?q=Projeto+GNOME
+.. _Damned Lies: https://duckduckgo.com/?q=Damned+Lies
+.. _Open-Tran: https://duckduckgo.com/?q=Open-Tran
+.. _LDP: https://duckduckgo.com/?q=LDP
+.. _Leslie Watter: https://duckduckgo.com/?q=Leslie+Watter
+.. _GNOME Bugzilla: https://duckduckgo.com/?q=GNOME+Bugzilla
+.. _Projeto KDE: https://duckduckgo.com/?q=Projeto+KDE
+.. _C++: https://duckduckgo.com/?q=C++
+.. _Vala: https://duckduckgo.com/?q=Vala
+.. _Arch Linux: https://duckduckgo.com/?q=Arch+Linux
+.. _Papo de Buteco (DuckDuckGo): https://duckduckgo.com/?q=Papo+de+Buteco
+.. _Open Cast: https://duckduckgo.com/?q=Open+Cast
+.. _Papo de Buteco: http://papodebuteco.net/

--- a/content/episodes/055-editor-vim.rst
+++ b/content/episodes/055-editor-vim.rst
@@ -38,12 +38,11 @@ editar o áudio, então a resposta era não.
 
 .. more
 
-Eis que nas últimas semanas, tendo participado como convidado do
-`Opencast <http://tecnologiaaberta.com.br/>`__ podcast, aquela vontade
-enorme que eu tive para começar o Castálio podcast voltou com uma força
-total, e depois de bater um papo com meu amigo Evandro Pastor, muso
-inspirador e responsável principal pela criação deste, decidi voltar a
-fazer o podcast, porém com algumas mudanças:
+Eis que nas últimas semanas, tendo participado como convidado do `Opencast`_
+podcast, aquela vontade enorme que eu tive para começar o Castálio podcast
+voltou com uma força total, e depois de bater um papo com meu amigo Evandro
+Pastor, muso inspirador e responsável principal pela criação deste, decidi
+voltar a fazer o podcast, porém com algumas mudanças:
 
 1. Ao invés de somente fazer episódios de entrevistas (que realmente é
    mais complicado devido ao agendamento com convidados, etc), desta vez
@@ -64,15 +63,11 @@ fazer o podcast, porém com algumas mudanças:
    nosso "pão de cada dia" aqui na Red Hat). Um dia desses vou mostrar
    como que as coisas estão...
 
-Para finalizar, eu não estaria aqui, depois de ter passado um tempinho
-editando um bate-papo que tive com o Elyézer esta última semana, se não
-fosse por vocês que deixaram comentários aqui, no Twitter, pedindo pela
-volta do podcast... e especialmente quero deixar aqui o meu
-agradecimento ao `Ivan
-Fuzzer <http://www.castalio.info/ivan-brasil-fuzzer-ubuntero/>`__ e
-`Evandro
-Pastor <http://www.castalio.info/evandro-pastor-quarto-estudio/>`__,
-pelo apoio e incentivo para voltar! Muito obrigado mesmo!
+Para finalizar, eu não estaria aqui, depois de ter passado um tempinho editando
+um bate-papo que tive com o Elyézer esta última semana, se não fosse por vocês
+que deixaram comentários aqui, no Twitter, pedindo pela volta do podcast...
+e especialmente quero deixar aqui o meu agradecimento ao `Ivan Fuzzer`_
+e `Evandro Pastor`_, pelo apoio e incentivo para voltar! Muito obrigado mesmo!
 
 Então, para nosso primeiro episódio temático decidimos falar sobre o
 editor Vim, aquele editor que vem instalado por padrão na maioria das
@@ -99,27 +94,27 @@ Escute Agora
 Links
 -----
 
--  `Editor Vim <http://www.vim.org/>`__
--  `Github <http://github.com>`__
--  `Gist <http://gist.github.com>`__
--  `Cygwin <https://cygwin.com/>`__
+-  `Editor Vim`_
+-  `Github`_
+-  `Gist`_
+-  `Cygwin`_
 -  Gerenciadores de plugins:
 
-   -  `Vundle <https://github.com/gmarik/Vundle.vim>`__
-   -  `NeoBundle <https://github.com/Shougo/neobundle.vim>`__ (versão melhorada do Vundle)
+   -  `Vundle`_
+   -  `NeoBundle`_ (versão melhorada do Vundle)
 
--  `Vim Bootstrap <http://vim-bootstrap.com/>`__ (`vim-bootstrap <https://github.com/avelino/vim-bootstrap>`__ no Github, consulte para uma `lista de atalhos <https://github.com/avelino/vim-bootstrap#commands>`__)
--  `oh-my-vim <https://github.com/liangxianzhe/oh-my-vim>`__
--  `oh-my-zsh <https://github.com/robbyrussell/oh-my-zsh>`__ (framework para o zsh)
--  `vim-solarized <https://github.com/altercation/vim-colors-solarized>`__ (tema de cores)
--  `Syntastic <https://github.com/scrooloose/syntastic>`__ (plugin para verificação da sintaxe)
--  `vim-fugitive <https://github.com/tpope/vim-fugitive>`__ (git wrapper para o vim)
--  `ctrlp plugin <https://github.com/kien/ctrlp.vim>`__
--  `gist-vim plugin <https://github.com/mattn/gist-vim>`__
--  `jedi-vim plugin <https://github.com/davidhalter/jedi-vim>`__
--  `Snippets plugin <https://github.com/SirVer/ultisnips>`__
--  `Pacote com vários plugins <https://github.com/honza/vim-snippets>`__
--  `.vim Elyézer <https://github.com/elyezer/.vim>`__
+-  `Vim Bootstrap`_ (`vim-bootstrap`_ no Github, consulte para uma `lista de atalhos`_)
+-  `oh-my-vim`_
+-  `oh-my-zsh`_ (framework para o zsh)
+-  `vim-solarized`_ (tema de cores)
+-  `Syntastic`_ (plugin para verificação da sintaxe)
+-  `vim-fugitive`_ (git wrapper para o vim)
+-  `ctrlp plugin`_
+-  `gist-vim plugin`_
+-  `jedi-vim plugin`_
+-  `Snippets plugin`_
+-  `Pacote com vários plugins`_
+-  `.vim Elyézer`_
 
 Entrando e saindo do modo de edição no Vim
 ------------------------------------------
@@ -147,3 +142,26 @@ modo visual, mas selecionando linhas. Ao realizar uma seleção utilize
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _Opencast: http://tecnologiaaberta.com.br/
+.. _Ivan Fuzzer: http://www.castalio.info/ivan-brasil-fuzzer-ubuntero/
+.. _Evandro Pastor: http://www.castalio.info/evandro-pastor-quarto-estudio/
+.. _Editor Vim: http://www.vim.org/
+.. _Github: http://github.com
+.. _Gist: http://gist.github.com
+.. _Cygwin: https://cygwin.com/
+.. _Vundle: https://github.com/gmarik/Vundle.vim
+.. _NeoBundle: https://github.com/Shougo/neobundle.vim
+.. _Vim Bootstrap: http://vim-bootstrap.com/
+.. _oh-my-vim: https://github.com/liangxianzhe/oh-my-vim
+.. _oh-my-zsh: https://github.com/robbyrussell/oh-my-zsh
+.. _vim-solarized: https://github.com/altercation/vim-colors-solarized
+.. _Syntastic: https://github.com/scrooloose/syntastic
+.. _vim-fugitive: https://github.com/tpope/vim-fugitive
+.. _ctrlp plugin: https://github.com/kien/ctrlp.vim
+.. _gist-vim plugin: https://github.com/mattn/gist-vim
+.. _jedi-vim plugin: https://github.com/davidhalter/jedi-vim
+.. _Snippets plugin: https://github.com/SirVer/ultisnips
+.. _Pacote com vários plugins: https://github.com/honza/vim-snippets
+.. _.vim Elyézer: https://github.com/elyezer/.vim
+.. _vim-bootstrap: https://github.com/avelino/vim-bootstrap
+.. _lista de atalhos: https://github.com/avelino/vim-bootstrap#commands

--- a/content/episodes/056-splinter.rst
+++ b/content/episodes/056-splinter.rst
@@ -63,9 +63,7 @@ pagina que foi aberta no navegador e salva no arquivo de sistemas:
 
    Editor Vim
 
-O bacana é que o método que tira screenshots foi
-`contribuição <https://github.com/cobrateam/splinter/commit/9913fbb236455fdd94aaa06317536a74c4cd780a>`__
-minha. :)
+O bacana é que o método que tira screenshots foi `contribuição`_ minha. :)
 
 Agora, vamos fazer a mesma coisa, mas desta vez usando o **Selenium
 WebDriver**:
@@ -143,11 +141,11 @@ Escute Agora
 Links
 -----
 
--  `Splinter <http://splinter.cobrateam.info/en/latest/>`__
--  `Selenium <http://docs.seleniumhq.org/>`__
--  `Selenium IDE <http://docs.seleniumhq.org/projects/ide/>`__
--  `Selenium WebDriver <http://docs.seleniumhq.org/projects/webdriver/>`__
--  `Satellite 6 <https://www.youtube.com/watch?v=BlNl7BJTUBs&list=PLcvmpY7C1j8l2rizvq7HLxLxX2fZioEuw>`__
+-  `Splinter`_
+-  `Selenium`_
+-  `Selenium IDE`_
+-  `Selenium WebDriver`_
+-  `Satellite 6`_
 
 .. class:: panel-body bg-info
 
@@ -156,3 +154,9 @@ Links
 .. Footer
 .. _Ain't Gonna Give Jelly Roll: http://freemusicarchive.org/music/Red_Hook_Ramblers/Live__WFMU_on_Antique_Phonograph_Music_Program_with_MAC_Feb_8_2011/Red_Hook_Ramblers_-_12_-_Aint_Gonna_Give_Jelly_Roll
 .. _Red Hook Ramblers: http://www.redhookramblers.com/
+.. _contribuição: https://github.com/cobrateam/splinter/commit/9913fbb236455fdd94aaa06317536a74c4cd780a
+.. _Splinter: http://splinter.cobrateam.info/en/latest/
+.. _Selenium: http://docs.seleniumhq.org/
+.. _Selenium IDE: http://docs.seleniumhq.org/projects/ide/
+.. _Selenium WebDriver: http://docs.seleniumhq.org/projects/webdriver/
+.. _Satellite 6: https://www.youtube.com/watch?v=BlNl7BJTUBs&list=PLcvmpY7C1j8l2rizvq7HLxLxX2fZioEuw

--- a/content/news/castalio-podcast-primeiro-ano-e-bastidores.rst
+++ b/content/news/castalio-podcast-primeiro-ano-e-bastidores.rst
@@ -5,13 +5,18 @@ Castálio Podcast: Primeiro Ano e Bastidores
 :category: Notícia
 :tags: aniversário, bastidores
 
-|1º Aniversário|\ No dia 16 de fevereiro de 2011, de forma simples e
-despretenciosa, foi publicado o primeiro episódio do `Castálio
-Podcast <http://castalio.info>`__! Veterano de alguns podcast nos
-últimos anos (quem ainda se lembra do **Ubuntu Brasil** e
-`Foocast <http://foocast.wordpress.com/>`__ podcasts?), foi com um pouco
-de incerteza que eu decidi iniciar este projeto "com o objetivo de
-entrevistar e ao mesmo tempo apresentar pessoas e projetos que sejam
+.. image:: http://farm8.staticflickr.com/7014/6768863505_0bf59f76a3_m_d.jpg
+    :alt: Happy Birthday
+    :target: http://farm8.staticflickr.com/7014/6768863505_0bf59f76a3_m_d.jpg
+    :align: left
+
+
+No dia 16 de fevereiro de 2011, de forma simples e despretenciosa, foi
+publicado o primeiro episódio do `Castálio Podcast`_! Veterano de alguns
+podcast nos últimos anos (quem ainda se lembra do **Ubuntu Brasil**
+e `Foocast`_ podcasts?), foi com um pouco de incerteza que eu decidi
+iniciar este projeto "com o objetivo de entrevistar e ao mesmo tempo
+apresentar pessoas e projetos que sejam
 fonte de inspiração para os ouvintes".
 
     "O Castalio é sensacional e muito bem feito. O Og conduz tudo muito
@@ -23,8 +28,7 @@ fonte de inspiração para os ouvintes".
     estar em uma mesa de bar com o Og e o entrevistado. Enfim, esse
     podcast é extremamente recomendado.
 
-    Ah! E, por favor, alguém entreviste o Og algum dia." - `Hugo
-    Doria <http://hdoria.com/>`__
+    Ah! E, por favor, alguém entreviste o Og algum dia." - `Hugo Doria`_
 
 Invés de juntar com uns amigos e discutir sobre tecnologia e assuntos do
 dia, eu queria fazer algo um pouco mais diferente e evitar aquela rotina
@@ -35,7 +39,7 @@ esta meta que eu iniciei o processo de entrevistar uma pessoa de 15 em
 
     "Bate-papo informal com nomes de que você encontra facilmente em
     listas de discussões na Internet? Castalio podcast é o lugar." -
-    `Diego Búrigo Zacarão <http://diegobz.net/>`__
+    `Diego Búrigo Zacarão`_
 
 Durante o percurso dos últimos 12 meses eu tive de aprender muitas
 coisas relacionadas ao processo de edição de áudio, uma coisa que até
@@ -51,8 +55,7 @@ mais fluído sem longas pausas.
     Informativo, mas sempre na forma de uma conversa agradável! Além
     disso, também está se tornando um verdadeiro 'portal do tempo' que
     permite aos membros recentes saberem mais sobre os primórdios.
-    Parabéns ao Og pela iniciativa e por todo o esforço!" - `Marcelo
-    Hashimoto <https://launchpad.net/polly>`__
+    Parabéns ao Og pela iniciativa e por todo o esforço!" - `Marcelo Hashimoto`_
 
 Ao mesmo tempo que eu queria publicar um áudio legal, eu também queria
 providenciar mais informações sobre os tópicos discutidos no episódio
@@ -74,7 +77,7 @@ fazer algo para melhorar o meu trabalho.
     essência das comunidades se perde pois as comunidades são feitas de
     pessoas e suas iniciativas e motivações pessoais. Em suma, esta é a
     verdadeira história do SL no Brasil e você está contando! Parabéns,
-    Og!" - `acris <http://softwarelivre.org/acris/blog>`__
+    Og!" - `acris`_
 
 Para quem não sabe, profissionalmente eu trabalho na criação de testes e
 automatização de máquinas virtuais, e quando não estou lidando com as
@@ -95,8 +98,7 @@ notas para o meu programa, e pronto!
     oportunidades mais interessantes que tive na comunidade de código
     aberto. Entretanto, melhor do que isso foi conhecer meus próprios
     amigos e colegas sob uma perspectiva diferente, por meio de
-    episódios sempre divertidos e inusitados." - `Igor
-    Soares <http://igorsoares.com/>`__
+    episódios sempre divertidos e inusitados." - `Igor Soares`_
 
 Uma vez que eu demorava menos tempo compondo o post, eu tive mais tempo
 para me dedicar a pesquisar mais sobre os entrevistados, montar uma
@@ -125,7 +127,7 @@ vida!
     comunidade nacional de outra distribuição) que expõem detalhes que
     mesmo os participantes das comunidades em questão geralmente
     desconhecem, e o fazem de maneira leve e interessante. Continue com
-    o sucesso!" - `Augusto Campos <http://augustocampos.net/>`__
+    o sucesso!" - `Augusto Campos`_
 
 Então muitíssimo obrigado a todos vocês que, de uma forma ou outra
 participaram do processo deste projeto, e espero poder trazer uma nova
@@ -133,4 +135,11 @@ série de entrevistados e assuntos neste ano de 2012, e poder
 compartilhar com vocês um pouco de destes bate-papos prá lá de
 interessantes e divertidos!
 
-.. |1º Aniversário| image:: http://farm8.staticflickr.com/7014/6768863505_0bf59f76a3_m_d.jpg
+.. _Castálio Podcast: http://castalio.info
+.. _Foocast: http://foocast.wordpress.com/
+.. _Hugo Doria: http://hdoria.com/
+.. _Diego Búrigo Zacarão: http://diegobz.net/
+.. _Marcelo Hashimoto: https://launchpad.net/polly
+.. _acris: http://softwarelivre.org/acris/blog
+.. _Igor Soares: http://igorsoares.com/
+.. _Augusto Campos: http://augustocampos.net/

--- a/content/news/em-memoria-de-andre-gondim.rst
+++ b/content/news/em-memoria-de-andre-gondim.rst
@@ -4,7 +4,8 @@ Em Memória de André Gondim
 :author: Og Maciel
 :category: Notícia
 
-O **Castálio Podcast** está de luto devido ao falecimento de `André
-Gondim <http://andregondim.eti.br/>`__, um colaborador do mundo de
-traduções do software livre, um exemplo de luta e um amigo! **Descanse
-em paz André**!!!
+O **Castálio Podcast** está de luto devido ao falecimento de `André Gondim`_,
+um colaborador do mundo de traduções do software livre, um exemplo de luta e um
+amigo! **Descanse em paz André**!!!
+
+.. _André Gondim: http://andregondim.eti.br/

--- a/content/news/premio-fridaigf-2011.rst
+++ b/content/news/premio-fridaigf-2011.rst
@@ -9,12 +9,13 @@ Prêmio FRIDA/IGF 2011
 
    Prêmio Frida
 
-O **Castálio Podcast** está concorrendo ao `Prêmio FRIDA/IGF
-2011 <http://premiofrida.org/por/>`__ no tema "Acesso". O Prêmio FRIDA
-pretende reconhecer projetos e iniciativas que colaborem de forma
-significativa com o uso da Internet como catalisador para a mudança na
-**América Latina** e o **Caribe**.
+O **Castálio Podcast** está concorrendo ao `Prêmio FRIDA/IGF 2011`_ no tema
+"Acesso". O Prêmio FRIDA pretende reconhecer projetos e iniciativas que
+colaborem de forma significativa com o uso da Internet como catalisador para
+a mudança na **América Latina** e o **Caribe**.
 
-Caso você tenha interesse e um tempo livre, vote no
-`Castálio <http://premiofrida.org/por/projects/view/1424>`__ e outros
+Caso você tenha interesse e um tempo livre, vote no `Castálio`_ e outros
 projetos que também estão concorrendo!
+
+.. _Prêmio FRIDA/IGF 2011: http://premiofrida.org/por/
+.. _Castálio: http://premiofrida.org/por/projects/view/1424

--- a/content/news/proximo-episodio-carlos-ribeiro-radiotray.rst
+++ b/content/news/proximo-episodio-carlos-ribeiro-radiotray.rst
@@ -10,10 +10,11 @@ Próximo Episódio: Carlos Ribeiro - RadioTray
 
    RadioTray
 
-Olá pessoal! Só queria avisar que o meu próximo convidado será o
-**Carlos Ribeiro** do projeto
-`RadioTray <http://radiotray.sourceforge.net/>`__! O Carlos vai estar
-falando direto de **Portugal** comigo pelo Skype, e eu estou
-interessadíssimo em saber um pouco mais sobre o seu projeto e como é a
-cultura de ser um programador na Europa! Caso vocês queiram participar
-deste episódio, deixe suas perguntas aqui nos comentários.
+Olá pessoal! Só queria avisar que o meu próximo convidado será o **Carlos
+Ribeiro** do projeto `RadioTray`_! O Carlos vai estar falando direto de
+**Portugal** comigo pelo Skype, e eu estou interessadíssimo em saber um pouco
+mais sobre o seu projeto e como é a cultura de ser um programador na Europa!
+Caso vocês queiram participar deste episódio, deixe suas perguntas aqui nos
+comentários.
+
+.. _RadioTray: http://radiotray.sourceforge.net/

--- a/content/news/um-ano-de-dados.rst
+++ b/content/news/um-ano-de-dados.rst
@@ -13,8 +13,8 @@ de vida!
    :alt: Google Analytics
 
    Google Analytics
+
 .. figure:: {filename}/images/castalio-1-ano-wordpress.png
    :alt: WordPress
 
    WordPress
-


### PR DESCRIPTION
Replace all inline links for reference links.

Inline Link example:

    `link name <http://linkurl.com>`_

Reference Link example:

    `link name`_
    
    .. _link name:  http://linkurl.com

The reference link approach keeps the text more readable and allow links reuse.

P.S.: It looks like one hell of a work, but thanks to VIM it was made in less then half an hour :D