### PR TITLE
Adds a download statistics target

### DIFF
--- a/.scripts/stats.py
+++ b/.scripts/stats.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+import re
+import sys
+import os
+import urllib2
+import json
+import codecs
+
+def print_summary(stats):
+    total = sum(stats.values())
+    average = float(total)/len(stats)
+    most_downloaded = max(*stats.items(), key=lambda x:x[1])
+    least_downloaded = min(*stats.items(), key=lambda x:x[1])
+
+    print "\n"
+    print "Most downloaded episode: {} ({})".format(*most_downloaded)
+    print "Least downloaded episode: {} ({})".format(*least_downloaded)
+    print "Total of Downloads: {}".format(total)
+    print "Average of Downloads: {}".format(round(average, 2))
+
+
+def print_stats(name, count):
+    print "{}: {}".format(name, count)
+
+def get_download_count(url):
+    code = None
+    try:
+        connection = urllib2.urlopen(url)
+        code = ''.join(connection.readlines())
+        connection.close()
+    except urllib2.HTTPError, e:
+        print "Error reading %s"%url
+    jobject = json.loads(code)
+    return jobject['item']['downloads']
+
+def get_name_and_url(fname):
+    if not os.path.exists(fname):
+        print "File not found: {}".format(fname)
+        return (None, None)
+
+    if os.path.isdir(fname):
+        print "Ignoring folder {} and it's contents".format(fname)
+        return (None, None)
+
+    if not fname.endswith(".rst"):
+        print "Not an rst file: {}".format(fname)
+        return (None, None)
+
+    with codecs.open(fname, 'r', 'utf-8') as fd:
+        for line in fd:
+            match =  re.match("^\.\. podcast:: (.*)$", line)
+
+            if match:
+                break
+        else:
+            print "File '{}' isn't about an episode!".format(fname)
+            return (None, None)
+
+    archive_episode_name = match.groups()[0]
+    url = "https://archive.org/details/{}&output=json".format(archive_episode_name)
+    return (archive_episode_name, url)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) <= 1:
+        print "Usage: {} <rst_file> ...".format(sys.argv[0])
+        exit(1)
+
+    stats = {}
+    episodes = sorted(sys.argv[1:])
+    for episode in episodes:
+        (name, url) = get_name_and_url(episode)
+        if not url:
+            continue
+        count = get_download_count(url)
+        stats[name] = count
+        print_stats(name, count)
+    if len(stats) > 2:
+        print_summary(stats)
+    exit(0)

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ help:
 	@echo '   make cf_upload                   upload the web site via Cloud Files'
 	@echo '   make github                      upload the web site via gh-pages   '
 	@echo '   make travis                      upload the web site via travis   '
+	@echo '   make stats                       queries Archive.org an list download statistics'
 	@echo '                                                                       '
 	@echo 'Set the DEBUG variable to 1 to enable debugging, e.g. make DEBUG=1 html'
 	@echo '                                                                       '
@@ -112,4 +113,7 @@ travis: publish
 	ghp-import  -m "Updated podcast site." -b $(GITHUB_PAGES_BRANCH) $(OUTPUTDIR)
 	@git push -fq https://${GH_TOKEN}@github.com/CastalioPodcast/CastalioPodcast.github.io.git master > /dev/null
 
-.PHONY: html help clean regenerate serve devserver publish ssh_upload rsync_upload dropbox_upload ftp_upload s3_upload cf_upload github travis
+stats:
+	./.scripts/stats.py content/episodes/*.rst
+
+.PHONY: html help clean regenerate serve devserver publish ssh_upload rsync_upload dropbox_upload ftp_upload s3_upload cf_upload github travis stats


### PR DESCRIPTION
Adds a 'stats' directive in Makefile, which queries Archive.org API and
lists the download statistics for all episodes. 

    $ make stats

For download statistics
of a single episode (or specific set of episodes) call the python
script directly:

    $ ./.scripts/stats.py content/episodes/057-natal-parte-1.rst