### PR TITLE
Fix `:author:` metatag for multiple authors

### DIFF
--- a/content/episodes/055-editor-vim.rst
+++ b/content/episodes/055-editor-vim.rst
@@ -1,7 +1,7 @@
 Episódio 55: Editor Vim
 #######################
 :date: 2014-11-23 18:44
-:author: Og Maciel e Elyézer Rezende
+:authors: Og Maciel, Elyézer Rezende
 :category: Podcast
 :podcast: https://archive.org/download/castalio-podcast-55/castalio-podcast-55.mp3
 :tags: github, vim

--- a/content/episodes/056-splinter.rst
+++ b/content/episodes/056-splinter.rst
@@ -1,7 +1,7 @@
 Episódio 56: Splinter
 #####################
 :date: 2014-12-07
-:author: Og Maciel e Elyézer Rezende
+:authors: Og Maciel, Elyézer Rezende
 :category: Podcast
 :podcast: https://archive.org/download/castalio-podcast-56/castalio-podcast-56.mp3
 :tags: splinter, selenium, automatização, splinter, selenium, python

--- a/content/episodes/057-natal-parte-1.rst
+++ b/content/episodes/057-natal-parte-1.rst
@@ -1,7 +1,7 @@
 Episódio 57: Episódio de Natal - Parte 1
 ########################################
 :date: 2014-12-20
-:author: Og Maciel e Elyézer Rezende
+:authors: Og Maciel, Elyézer Rezende
 :category: Podcast
 :podcast: https://archive.org/download/castalio-podcast-57/castalio-podcast-57.mp3
 :tags: grokpodcast, hack 'n' cast, natal, podcast

--- a/content/episodes/058-natal-parte-2.rst
+++ b/content/episodes/058-natal-parte-2.rst
@@ -1,7 +1,7 @@
 Episódio 58: Episódio de Natal - Parte 2
 ########################################
 :date: 2014-12-21
-:author: Og Maciel e Elyézer Rezende
+:authors: Og Maciel, Elyézer Rezende
 :category: Podcast
 :podcast: https://archive.org/download/castalio-podcast-58/castalio-podcast-58.mp3
 :tags: grokpodcast, hack 'n' cast, natal, podcast, audacity

--- a/content/episodes/059-natal-parte-3.rst
+++ b/content/episodes/059-natal-parte-3.rst
@@ -1,7 +1,7 @@
 Episódio 59: Episódio de Natal - Parte 3
 ########################################
 :date: 2014-12-22
-:author: Og Maciel e Elyézer Rezende
+:authors: Og Maciel, Elyézer Rezende
 :category: Podcast
 :podcast: https://archive.org/download/castalio-podcast-59/castalio-podcast-59.mp3
 :tags: grokpodcast, hack 'n' cast, natal, podcast, jekyll, pelican,

--- a/content/episodes/060-andrews-medina-splinter.rst
+++ b/content/episodes/060-andrews-medina-splinter.rst
@@ -1,7 +1,7 @@
 Episódio 60: Andrews Medina - Splinter
 ######################################
 :date: 2015-01-04
-:author: Og Maciel e Elyézer Rezende
+:authors: Og Maciel, Elyézer Rezende
 :category: Podcast
 :podcast: https://archive.org/download/castalio-podcast-60/castalio-podcast-60.mp3
 :tags: andrews medina, splinter, tsuru, travis, cobra team, spotify,

--- a/content/episodes/061-humberto-zanetti-smart-braille.rst
+++ b/content/episodes/061-humberto-zanetti-smart-braille.rst
@@ -1,7 +1,7 @@
 Episódio 61: Humberto Augusto Piovesana Zanetti - Smart Braille
 ###############################################################
 :date: 2015-01-18
-:author: Og Maciel e Elyézer Rezende
+:authors: Og Maciel, Elyézer Rezende
 :category: Podcast
 :podcast: https://archive.org/download/castalio-podcast-61/castalio-podcast-61.mp3
 :tags: humberto augusto piovesana zanetti, smart braille

--- a/content/episodes/062-diego-rodrigo-santos-sobrecervejas.rst
+++ b/content/episodes/062-diego-rodrigo-santos-sobrecervejas.rst
@@ -1,7 +1,7 @@
 Episódio 62: Diego Rodrigo Santos - SobreCervejas
 #################################################
 :date: 2015-02-01
-:author: Og Maciel e Elyézer Rezende
+:authors: Og Maciel, Elyézer Rezende
 :category: Podcast
 :podcast: https://archive.org/download/castalio-podcast-62/castalio-podcast-62.mp3
 :tags: diego rodrigo santos, sobrecervejas, instagram, guinness, old

--- a/content/episodes/063-thiago-avelino-vim-bootstrap.rst
+++ b/content/episodes/063-thiago-avelino-vim-bootstrap.rst
@@ -1,7 +1,7 @@
 Episódio 63: Thiago Avelino - vim-bootstrap e BeerBlogging
 ##########################################################
 :date: 2015-02-15
-:author: Og Maciel e Elyézer Rezende
+:authors: Og Maciel, Elyézer Rezende
 :category: Podcast
 :podcast: https://archive.org/download/castalio-podcast-63/castalio-podcast-63.mp3
 :tags: thiago avelino, vim-bootstrap, beerblogging


### PR DESCRIPTION
Replaces `:author: Og Maciel e Elyézer Rezende` by `:authors: Og Maciel, Elyézer Rezende`, which is intepreted as separated authors. For a better understanding check the authors page: http://castalio.info/authors