### PR TITLE
Fix label alignment

### DIFF
--- a/themes/pelican-bootstrap3/static/css/style.css
+++ b/themes/pelican-bootstrap3/static/css/style.css
@@ -317,3 +317,8 @@ img.align-center, .figure.align-center{
 .post-info > span {
 	padding-right: 15px;
 }
+
+.post-info > span > span.label {
+	vertical-align: middle;
+	padding-top: 3px;
+}


### PR DESCRIPTION
The original alignment was a little awkward.

![fix-title-alignment](https://cloud.githubusercontent.com/assets/353311/6364058/e0e7d5a8-bc7f-11e4-83d6-4428290c2bd5.png)
