### PR TITLE
Adds downloads statistics

### DIFF
--- a/themes/pelican-bootstrap3/templates/article.html
+++ b/themes/pelican-bootstrap3/templates/article.html
@@ -68,6 +68,7 @@
 {% endblock %}
 
 {% block content %}
+    {% set IS_ARTICLE = True %}
     <section id="content">
         <article>
             <header class="page-header">
@@ -93,4 +94,17 @@
         </article>
     </section>
 
+{% endblock %}
+
+{% block scripts %}
+    {% if article.podcast %}
+        <script type="text/javascript">
+            function set_download_count(data) {
+                    $("#download-count").text(data.item.downloads);
+            }
+        </script>
+
+        <!-- archive meta -->
+        <script type="text/javascript" src="{{ 'http://archive.org/details/{}&callback=set_download_count?output=json'.format(article.podcast.split('/')[-2]) }}"></script>
+    {% endif %}
 {% endblock %}

--- a/themes/pelican-bootstrap3/templates/includes/article_info.html
+++ b/themes/pelican-bootstrap3/templates/includes/article_info.html
@@ -38,6 +38,14 @@
         </span>
     {% endif %}
 
+    {% if IS_ARTICLE is defined and article.podcast %}
+        <span class="podcast-download-count">
+            <span class="label label-default">Downloads</span>
+            <span id="download-count">-</span>
+        </span>
+    {% endif %}
+
+
     {#% include 'includes/taglist.html' %#}
     {% import 'includes/translations.html' as translations with context %}
     {{ translations.translations_for(article) }}


### PR DESCRIPTION
This commit adds a dynamic (through JavaScript) download statistics in the episode page (right below the episode title). I'm not adding these statistics to the index because I fear it can degrade the page loading
speed, since I'll be obligated to load the JSON object for every episode present in the index (10 episodes).

Demo:
![castalio-download-stats](https://cloud.githubusercontent.com/assets/353311/6386015/323e582e-bd51-11e4-92f1-8f139ebb3c00.png)