### PR TITLE
Fix white space wrap and line height

### DIFF
--- a/themes/pelican-bootstrap3/static/css/style.css
+++ b/themes/pelican-bootstrap3/static/css/style.css
@@ -314,8 +314,12 @@ img.align-center, .figure.align-center{
 	padding-left: 20px;
 }
 
+.post-info {
+    line-height: 1.7;
+}
 .post-info > span {
 	padding-right: 15px;
+    white-space: nowrap;
 }
 
 .post-info > span > span.label {


### PR DESCRIPTION
Hi there, long time since last PR!

This one fix 2 things that was annoying me in the article meta information: white space wrap and line height. 

The white space wrapping was causing the "label" and the "information" to appear in different lines:
![whitespace-wrap](https://cloud.githubusercontent.com/assets/353311/6630154/78c9b0be-c8f4-11e4-9808-537b2d59f5aa.png)

The line height was causing the labels to overlap each other in small devices:
![lineheight](https://cloud.githubusercontent.com/assets/353311/6630127/2923d2c4-c8f4-11e4-96ba-749836164ca8.png)

Thanks and keep up the good work!