### PR TITLE
Revert "Copy favicon.ico to the right place."

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -51,7 +51,6 @@ STATIC_PATHS = [
 EXTRA_PATH_METADATA = {
     'extra/CNAME': {'path': 'CNAME'},
     'extra/robots.txt': {'path': 'robots.txt'},
-    'images/favicon.ico': {'path': 'favicon.ico'},
 }
 
 THEME = './themes/pelican-bootstrap3'


### PR DESCRIPTION
Reverts CastalioPodcast/CastalioPodcast.github.io#48

I made a mistake in previous Pull Request, the favicon was on the right place and the FAVICON on the pelicanconf.py define the right path.

Sorry about that.