### PR TITLE
Remove M4A as supported audio option.

### DIFF
--- a/plugins/caster/caster.py
+++ b/plugins/caster/caster.py
@@ -46,7 +46,6 @@ class Podcast(Directive):
             <div class="podcast-download">
                 <span class="label label-success"><a href="https://archive.org/download/{title}/{title}.mp3"><i class="fa fa-download"></i> Download MP3</a></span>
                 <span class="label label-success"><a href="https://archive.org/download/{title}/{title}.ogg"><i class="fa fa-download"></i> Download OGG</a></span>
-                <span class="label label-success"><a href="https://archive.org/download/{title}/{title}.m4a"><i class="fa fa-download"></i> Download M4A</a></span>
             </div>
         </div>
         """.format(title=title, podcast_rss=rss, podcast_itunes=itunes)


### PR DESCRIPTION
I wanted to do this for a while and I finally got around to it. Since our iTunes feed uses MP3s, there is no need to generate and export a separate M4A audio file. Generating the MP3 alone is enough to get Ogg files automatically created for us by archive.org.