### PR TITLE
Changes post-meta link hover color

### DIFF
--- a/themes/pelican-bootstrap3/static/css/style.css
+++ b/themes/pelican-bootstrap3/static/css/style.css
@@ -33,6 +33,9 @@ body {
   padding-right: 20px;
   white-space: nowrap;
 }
+.post-meta a:hover {
+  color: #fefefe;
+}
 
 .post-body .panel-body:before {
   display: block;


### PR DESCRIPTION
Improves readability of hover links in post meta. 
![before-after](https://user-images.githubusercontent.com/353311/31323792-e6df9e0a-ac82-11e7-860a-5cab022af99e.png)
