### PR TITLE
Removed obsolete podcasts from Sites Amigos

### DIFF
--- a/themes/pelican-bootstrap3/templates/includes/footer.html
+++ b/themes/pelican-bootstrap3/templates/includes/footer.html
@@ -39,8 +39,6 @@
                    <li><a title="Og Maciel" href="http://omaciel.github.io/">Og Maciel</a></li>
                    <li><a title="Elyézer Rezende" href="http://elyezer.com">Elyézer Rezende</a></li>
                    <li><a title="Bruno Rocha" href="http://brunorocha.org">Bruno Rocha</a></li>
-                   <li><a title="OpenCast" href="http://tecnologiaaberta.com.br/category/opencast/">OpenCast</a></li>
-                   <li><a title="Grok Podcast" href="http://grokpodcast.com/">Grok Podcast</a></li>
                    <li><a title="Hack 'n' Cast" href="http://hackncast.org"> Hack 'n' Cast</a></li>
                </ul>
            </div>


### PR DESCRIPTION
Both Opencast and Grok Podcast are no longer in business.