### PR TITLE
Update more show notes to use the top5 directive

### DIFF
--- a/content/episodes/135-fernando-masanori-ensino-de-python-ao-redor-do-mundo.rst
+++ b/content/episodes/135-fernando-masanori-ensino-de-python-ao-redor-do-mundo.rst
@@ -51,26 +51,28 @@ Tópicos abordados neste episódio
 * O que o Masanori mais gosta na prática do mergulho?
 
 
-Top 5
-=====
+.. top5::
 
-* **Música**: `Coldplay - Viva la vida`_
-* **Música**: `MGMT - Kids`_
-* **Música**: `Blink - I miss you`_
-* **Música**: `Boy - We Were Here`_
-* **Música**: `Skank - Esquecimento`_
-* **Filme**: `Forrest Gump`_
-* **Filme**: `Guerra nas Estrelas - Imperio Contra Ataca`_
-* **Filme**: `Casa Blanca`_
-* **Filme**: `A Origem`_
-* **Filme**: `Doze homens e uma sentença`_
-* **Livro**: `Crime Castigo`_
-* **Livro**: `O Idiota`_
-* **Livro**: `Os Irmãos Karamazov`_
-* **Livro**: `Dostoevsky: A Writer in His Time`_
-* **Livro**: `A sutil arte de ligar o f*da-se`_
-* **Livro**: `Os Miseráveis`_
-* **Livro**: `Musashi`_
+    :book:
+        * Crime Castigo
+        * O Idiota
+        * Os Irmãos Karamazov
+        * Dostoevsky: A Writer in His Time
+        * A sutil arte de ligar o f*da-se
+        * Os Miseráveis
+        * Musashi
+    :movie:
+        * Forrest Gump
+        * Guerra nas Estrelas - Imperio Contra Ataca
+        * Casa Blanca
+        * A Origem
+        * Doze homens e uma sentença
+    :music:
+        * Coldplay - Viva la vida
+        * MGMT - Kids
+        * blink-182 - I miss you
+        * Boy - We Were Here
+        * Skank - Esquecimento
 
 
 Assista a gravação deste episódio
@@ -195,24 +197,6 @@ Links
 .. _Raspberry Pi Camera: https://www.raspberrypi.org/documentation/usage/camera/
 .. _Raspberry Pi: https://www.raspberrypi.org/
 .. _Software Quality Engineering (livro do Og Maciel): https://gumroad.com/l/software-quality-engineering
-
-.. _Coldplay - Viva la vida: https://www.last.fm/music/Coldplay/_/Viva+la+Vida
-.. _MGMT - Kids: https://www.last.fm/music/MGMT/_/Kids
-.. _Blink - I miss you: https://www.last.fm/music/blink-182/_/I+Miss+You
-.. _Boy - We Were Here: https://www.last.fm/music/Boy/_/We+Were+Here
-.. _Skank - Esquecimento: https://www.last.fm/music/Skank/_/Esquecimento
-.. _Forrest Gump: https://www.imdb.com/title/tt0109830
-.. _Guerra nas Estrelas - Imperio Contra Ataca: https://www.imdb.com/title/tt0080684
-.. _Casa Blanca: https://www.imdb.com/title/tt0034583/
-.. _A Origem: https://www.imdb.com/title/tt1375666/
-.. _Doze homens e uma sentença: https://www.imdb.com/title/tt0050083/
-.. _Crime Castigo: https://www.goodreads.com/book/show/7144.Crime_and_Punishment
-.. _O Idiota: https://www.goodreads.com/book/show/12505.The_Idiot
-.. _Os Irmãos Karamazov: https://www.goodreads.com/book/show/4934.The_Brothers_Karamazov
-.. _Dostoevsky\: A Writer in His Time: https://www.goodreads.com/book/show/4988505-dostoevsky
-.. _A sutil arte de ligar o f*da-se: https://www.goodreads.com/book/show/36516509-a-sutil-arte-de-ligar-o-f-da-se
-.. _Os Miseráveis: https://www.goodreads.com/book/show/18309595-os-miser-veis
-.. _Musashi: https://www.goodreads.com/book/show/102030.Musashi
 
 
 .. Footer

--- a/content/episodes/136-pizza-de-dados.rst
+++ b/content/episodes/136-pizza-de-dados.rst
@@ -41,42 +41,46 @@ Tópicos abordados neste episódio
 * Quais as recomendações para aprender mais sobre `data science`_?
 
 
-Top 3
-=====
+.. top5:: Top 3 - Gustavo Coelho
 
-Gustavo Coelho
---------------
+    :book:
+        * The Art of Strategy
+        * Weapons of Math Destruction
+        * Nas Montanhas da Loucura
+    :music:
+        * Queens of Stone Age - Go With the Glow
+        * The Black Keys
+        * Chaos Chaos
+    :movie:
+        * Memento
+        * Ressaca de Amor
+        * O Iluminado
+        * A Morte do Demônio
+        * Rick and Morty
+    :pizza:
+        * Catuperoni
+        * Aliche
+        * Frango com Catupiry
 
-* **Livro**: `The Art of Strategy`_
-* **Livro**: `Weapons of Math Destruction`_
-* **Livro**: `Nas Montanhas da Loucura`_
-* **Música**: `Queens of Stone Age - Go With the Glow`_
-* **Música**: `The Black Keys`_
-* **Música**: `Chaos Chaos`_
-* **Filme**: `Memento`_
-* **Filme**: `Ressaca de Amor`_
-* **Filme**: `O Iluminado`_
-* **Filme**: `A Morte do Demônio`_
-* **Série**: `Rick and Morty`_
-* **Pizza**: Catuperoni
-* **Pizza**: Aliche
-* **Pizza**: Frango com Catupiry
 
-Letícia Portella
-----------------
+.. top5:: Top 3 - Letícia Portella
 
-* **Livro**: `Shōgun`_
-* **Livro**: `As Crónicas de Gelo e Fogo`_
-* **Livro**: `How to Lie with Statistics`_
-* **Música**: `Thriller`_
-* **Música**: `Hospital Shirt`_
-* **Música**: `Riding With the King`_
-* **Filme**: `A Morte no Funeral`_
-* **Filme**: `O Incrível Exército Brancaleone`_
-* **Filme**: `RRRrrrr!!!`_
-* **Pizza**: Marguerita
-* **Pizza**: Peperoni
-* **Pizza**: Escarola com Bacon
+    :book:
+        * Shōgun
+        * As Crónicas de Gelo e Fogo
+        * How to Lie with Statistics
+    :music:
+        * Michael Jackson - Thriller
+        * Jason Myles Goss - Hospital Shirt
+        * B.B. King & Eric Clapton - Riding With the King
+    :movie:
+        * A Morte no Funeral
+        * O Incrível Exército Brancaleone
+        * RRRrrrr!!!
+    :pizza:
+        * Marguerita
+        * Peperoni
+        * Escarola com Bacon
 
 
 Assista a gravação deste episódio

--- a/content/episodes/137-vicente-marcal-filosofia-com-python.rst
+++ b/content/episodes/137-vicente-marcal-filosofia-com-python.rst
@@ -53,25 +53,27 @@ Tópicos abordados neste episódio
   a programação?
 
 
-Top 5
-=====
+.. top5::
 
-* **Livro**: `Modelo e Estrutura - Zelia Ramozzi`_
-* **Livro**: `Em Busca do Sentido da Obra de Jean Piaget - Zelia Ramozzi`_
-* **Livro**: `Adaptation vitale et psychologie de l'intelligence`_
-* **Livro**: `Biologia e Conhecimento`_
-* **Livro**: `A Psicanálise, sua imagem e seu público`_
-* **Livro**: `O Nascimento da Inteligência na Criança`_
-* **Música**: `Iron Maiden - Powerslave`_
-* **Música**: `Belphegor - Lucifer Incestus`_
-* **Música**: `Ratos de Porão - Conflito Violento`_
-* **Música**: `Cólera - Medo`_
-* **Música**: `Garotos Podres - Eu não sei o que quero`_
-* **Filme**: `Game of Thrones`_
-* **Filme**: `Grimm`_
-* **Filme**: `Gotham`_
-* **Filme**: `Mulher Maravilha`_
-* **Filme**: `The Dark Knight`_
+    :book:
+        * Modelo e Estrutura - Zelia Ramozzi
+        * Em Busca do Sentido da Obra de Jean Piaget - Zelia Ramozzi
+        * Adaptation vitale et psychologie de l'intelligence
+        * Biologia e Conhecimento
+        * A Psicanálise, sua imagem e seu público
+        * O Nascimento da Inteligência na Criança
+    :music:
+        * Iron Maiden - Powerslave
+        * Belphegor - Lucifer Incestus
+        * Ratos De Porão - Conflito Violento
+        * Cólera - Medo
+        * Garotos Podres - Eu não sei o que quero
+    :movie:
+        * Game of Thrones
+        * Grimm
+        * Gotham
+        * Mulher Maravilha
+        * The Dark Knight
 
 
 Assista a gravação deste episódio
@@ -160,23 +162,6 @@ Links
     **Música**: `Ain't Gonna Give Jelly Roll`_ by `Red Hook Ramblers`_ is licensed under a Creative Commons Attribution-NonCommercial-NoDerivatives (aka Music Sharing) License.
 
 .. Mentioned
-.. _Modelo e Estrutura - Zelia Ramozzi: https://www.estantevirtual.com.br/livros/zelia-ramozzi-chiarottino/piaget-modelo-e-estrutura/1711628536
-.. _Em Busca do Sentido da Obra de Jean Piaget - Zelia Ramozzi: https://www.estantevirtual.com.br/livros/zelia-ramozzi-chiarottino/em-busca-do-sentido-da-obra-de-jean-piaget/1815760251
-.. _Adaptation vitale et psychologie de l'intelligence: https://www.goodreads.com/book/show/7502434-adaptation-and-intelligence
-.. _Biologia e Conhecimento: https://www.goodreads.com/book/show/1814504.Biology_and_Knowledge
-.. _A Psicanálise, sua imagem e seu público: https://www.goodreads.com/book/show/14622485-la-psychanalyse-son-image-et-son-public
-.. _O Nascimento da Inteligência na Criança: https://www.goodreads.com/book/show/1728850.The_Origins_of_Intelligence_in_Children
-.. _Iron Maiden - Powerslave: https://www.last.fm/music/Iron+Maiden/Powerslave/Powerslave
-.. _Belphegor - Lucifer Incestus: https://www.last.fm/music/Belphegor/_/Lucifer+Incestus
-.. _Ratos de Porão - Conflito Violento: https://www.last.fm/music/Ratos+De+Por%C3%A3o/_/Conflito+Violento
-.. _Cólera - Medo: https://www.last.fm/music/C%C3%B3lera/_/Medo
-.. _Garotos Podres - Eu não sei o que quero: https://www.last.fm/music/Garotos+Podres/_/Eu+n%C3%A3o+sei+o+que+quero
-.. _Game of Thrones: https://www.imdb.com/title/tt0944947/
-.. _Grimm: https://www.imdb.com/title/tt1830617/
-.. _Gotham: https://www.imdb.com/title/tt3749900/
-.. _Mulher Maravilha: https://www.imdb.com/title/tt0451279/
-.. _The Dark Knight: https://www.imdb.com/title/tt0468569/
-
 .. _Bash: https://www.gnu.org/software/bash/
 .. _Beautiful Soup: https://www.crummy.com/software/BeautifulSoup/
 .. _Brasil.io: https://brasil.io/

--- a/content/episodes/138-ana-paula-gomes-qualidade-de-software.rst
+++ b/content/episodes/138-ana-paula-gomes-qualidade-de-software.rst
@@ -48,6 +48,7 @@ Tópicos abordados neste episódio
 
 
 .. top5::
+
     :book:
         * Why Nations Fail
         * How to Be Successful without Hurting Men's Feelings

--- a/content/episodes/139-elcio-ferreira-padroes-e-desenvolvimento-web.rst
+++ b/content/episodes/139-elcio-ferreira-padroes-e-desenvolvimento-web.rst
@@ -50,6 +50,7 @@ Tópicos abordados neste episódio
 
 
 .. top5::
+
     :book:
         * Stand Out of Our Light - James Williams
         * Dive into Python

--- a/content/episodes/140-eduardo-mendes-live-de-python.rst
+++ b/content/episodes/140-eduardo-mendes-live-de-python.rst
@@ -49,6 +49,7 @@ Tópicos abordados neste episódio
 
 
 .. top5::
+
     :book:
         * O Apanhador no Campo de Centeio
         * O Mestre e Margarida

--- a/content/episodes/141-george-guimaraes-code-review.rst
+++ b/content/episodes/141-george-guimaraes-code-review.rst
@@ -57,6 +57,7 @@ Tópicos abordados neste episódio
 
 
 .. top5::
+
     :book:
         * The Messy Middle
         * The Startup Owner's Manual

--- a/content/episodes/142-david-kopec-classic-computer-science-problems-in-python.rst
+++ b/content/episodes/142-david-kopec-classic-computer-science-problems-in-python.rst
@@ -70,6 +70,7 @@ good for all `Manning <https://www.manning.com/>`_ products in all formats.
 
 
 .. top5::
+
     :book:
         * The Republic
         * Creative Selection

--- a/content/episodes/143-victor-dias-universo-programado.rst
+++ b/content/episodes/143-victor-dias-universo-programado.rst
@@ -44,6 +44,7 @@ Tópicos abordados neste episódio
 
 
 .. top5::
+
     :book:
         * Homo Deus
         * O Guia do Mochileiro das Galáxias

--- a/plugins/castalio/top5.json
+++ b/plugins/castalio/top5.json
@@ -186,6 +186,9 @@
     "Elm in Action": {
       "url": "https://www.goodreads.com/book/show/31441704-elm-in-action"
     },
+    "Em Busca do Sentido da Obra de Jean Piaget - Zelia Ramozzi": {
+        "url": "https://www.estantevirtual.com.br/livros/zelia-ramozzi-chiarottino/em-busca-do-sentido-da-obra-de-jean-piaget/1815760251"
+    },
     "Ender’s Game": {
       "url": "https://www.goodreads.com/book/show/375802.Ender_s_Game"
     },
@@ -341,6 +344,9 @@
     },
     "Menino Maluquinho": {
       "url": "https://www.goodreads.com/book/show/1796355.O_Menino_Maluquinho"
+    },
+    "Modelo e Estrutura - Zelia Ramozzi": {
+        "url": "https://www.estantevirtual.com.br/livros/zelia-ramozzi-chiarottino/piaget-modelo-e-estrutura/1711628536"
     },
     "Monteiro Lobato": {
       "url": "https://www.goodreads.com/author/show/2450573.Monteiro_Lobato"
@@ -2473,6 +2479,14 @@
     "blink-182 - I miss you": {
       "url": "https://www.last.fm/music/blink-182/_/I+Miss+You"
     }
+  },
+  "pizza": {
+    "Aliche": {},
+    "Catuperoni": {},
+    "Escarola com Bacon": {},
+    "Frango com Catupiry": {},
+    "Marguerita": {},
+    "Peperoni": {}
   },
   "podcast": {
     "Um Milkshake Chamado Wanda": {


### PR DESCRIPTION
Do the following:

* Make use of the `top5` directive on the show notes for episodes 135,
  136 and 137
* Improve the directive to accept a custom title
* Update directive usage on episodes 137-143 now that the directive
  accepts a custom title
* Update the `top5.json` with the pizza category and some missing
  entries.